### PR TITLE
Fix a number of issues with the parser

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ add_project_arguments(
     '-Werror=switch-enum',
     '-Werror=implicit-fallthrough',
     '-Werror=return-type',
+    '-Werror=unused-result',
   ),
   '-D_GNU_SOURCE',
   language : 'cpp',

--- a/src/frontend/driver.cpp
+++ b/src/frontend/driver.cpp
@@ -25,7 +25,10 @@ std::unique_ptr<AST::CodeBlock> Driver::parse(std::istream & iss) {
     auto scanner = std::make_unique<Frontend::Scanner>(&iss, name);
     auto parser = std::make_unique<Frontend::Parser>(*scanner, block);
 
-    parser->parse();
+    int res = parser->parse();
+    if (res != 0) {
+        throw std::exception{};
+    }
 
     std::vector<AST::StatementV> new_stmts{};
 

--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -109,7 +109,7 @@ continue                        { return token::CONTINUE; }
 :                               { return token::COLON; }
 \?                              { return token::QMARK; }
 \.                              { return token::DOT; }
-\#.*\n?                         { }
+\#.*\n?                         { loc->lines(); }
 .                               { yyterminate(); }
 
 %%

--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -59,6 +59,7 @@ static std::string strbuffer{};
                                     loc->lines();
                                 }
 "#".*                           { }
+\\\n                            { loc-> lines(); }
 \n                              {
                                     // Newlines are only significant as
                                     // statement separators We want to ignore

--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -38,6 +38,8 @@ Frontend::AST::AssignOp from_str(const std::string & s) {
     }
 }
 
+static std::string strbuffer{};
+
 %}
 
 %option debug
@@ -46,6 +48,7 @@ Frontend::AST::AssignOp from_str(const std::string & s) {
 %option noyywrap
 %option c++
 
+%x STRING_STATE
 %%
 
 [ \t]+                          { }
@@ -71,7 +74,22 @@ break                           { return token::BREAK; }
 continue                        { return token::CONTINUE; }
 [a-zA-Z_][a-zA-Z0-9_]*          { lval->build<std::string>(yytext); return token::IDENTIFIER; }
 [']{3}([']{0,2}([^\\']|\\(.|\n)))*[']{3} { lval->build<std::string>(yytext); return token::TSTRING; }
-'[^']*'                         { lval->build<std::string>(yytext); return token::STRING; }
+\'                              {
+                                    BEGIN(STRING_STATE);
+                                    strbuffer.clear();
+                                    strbuffer.append(yytext);
+                                }
+<STRING_STATE>\\'               { strbuffer.append("'"); }
+<STRING_STATE>\\n               { strbuffer.append("\n"); }
+<STRING_STATE>\\t               { strbuffer.append("\t"); }
+<STRING_STATE>\\\\              { strbuffer.append("\\"); }
+<STRING_STATE>[^']              { strbuffer.append(yytext); }
+<STRING_STATE>\'                {
+                                    strbuffer.append(yytext);
+                                    lval->build<std::string>(strbuffer);
+                                    BEGIN(INITIAL);
+                                    return token::STRING;
+                                }
 0x[0-9a-fA-F]+                  { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 16)); return token::HEX_NUMBER; }
 0o[0-7]+                        { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 8)); return token::OCTAL_NUMBER; }
 [0-9]+                          { lval->build<int64_t>(std::stoll(yytext)); return token::DECIMAL_NUMBER; }
@@ -91,7 +109,7 @@ continue                        { return token::CONTINUE; }
 :                               { return token::COLON; }
 \?                              { return token::QMARK; }
 \.                              { return token::DOT; }
-"#".*\n?                        { }
+\#.*\n?                         { }
 .                               { yyterminate(); }
 
 %%

--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -51,13 +51,20 @@ static std::string strbuffer{};
 %x STRING_STATE
 %%
 
+    /* This is gross, but this is more working around how annoying newlines are in meson */
+^[ \t]*"#".*\n?                 { loc->lines(); }
 [ \t]+                          { }
-^\s*\n                          { loc->lines(); }
+^\s*\n                          {
+                                    // We don't want to return a token, as there was no statement
+                                    loc->lines();
+                                }
+"#".*                           { }
 \n                              {
-                                    // Newlines are only significant as statement separators
-                                    // We want to ignore them inside of braces,
-                                    // as only expressions and not statements
-                                    // are allowed
+                                    // Newlines are only significant as
+                                    // statement separators We want to ignore
+                                    // them inside of braces, as only
+                                    // expressions and not statements are
+                                    // allowed.
                                     loc->lines();
                                     if (!brace()) { return token::NEWLINE; }
                                 }
@@ -109,7 +116,6 @@ continue                        { return token::CONTINUE; }
 :                               { return token::COLON; }
 \?                              { return token::QMARK; }
 \.                              { return token::DOT; }
-\#.*\n?                         { loc->lines(); }
 .                               { yyterminate(); }
 
 %%

--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -48,7 +48,7 @@ Frontend::AST::AssignOp from_str(const std::string & s) {
 
 %%
 
-[ \t]                           { }
+[ \t]+                          { }
 ^\s*\n                          { loc->lines(); }
 \n                              {
                                     // Newlines are only significant as statement separators

--- a/src/frontend/node.hpp
+++ b/src/frontend/node.hpp
@@ -505,15 +505,21 @@ class IfStatement {
 class ForeachStatement {
   public:
     ForeachStatement(Identifier && i, ExpressionV && e, std::unique_ptr<CodeBlock> && b)
-        : id{std::move(i)}, expr{std::move(e)}, block{std::move(b)} {};
+        : id{std::move(i)}, id2{std::nullopt}, expr{std::move(e)}, block{std::move(b)} {};
+    ForeachStatement(Identifier && i, Identifier && j, ExpressionV && e,
+                     std::unique_ptr<CodeBlock> && b)
+        : id{std::move(i)}, id2{std::move(j)}, expr{std::move(e)}, block{std::move(b)} {};
     ForeachStatement(ForeachStatement && f) noexcept
-        : id{std::move(f.id)}, expr{std::move(f.expr)}, block{std::move(f.block)} {};
+        : id{std::move(f.id)}, id2{std::move(f.id2)}, expr{std::move(f.expr)}, block{std::move(
+                                                                                   f.block)} {};
     ForeachStatement(const ForeachStatement &) = delete;
     ~ForeachStatement(){};
 
     std::string as_string() const;
 
     Identifier id;
+    // Used only in dictionary iteration
+    std::optional<Identifier> id2;
     ExpressionV expr;
     std::unique_ptr<CodeBlock> block;
 };

--- a/src/frontend/parser.yy
+++ b/src/frontend/parser.yy
@@ -115,6 +115,12 @@ foreach_statement : FOREACH IDENTIFIER ":" expression "\n" statements "\n" ENDFO
                                                             AST::Identifier{$2, @2},
                                                             std::move($4), std::move($6));
                                                     }
+                  | FOREACH IDENTIFIER "," IDENTIFIER ":" expression "\n" statements "\n" ENDFOREACH {
+                                                        $$ = std::make_unique<AST::ForeachStatement>(
+                                                            AST::Identifier{$2, @4},
+                                                            AST::Identifier{$4, @4},
+                                                            std::move($6), std::move($8));
+                                                    }
                   ;
 
 if_statement : if_clause ENDIF                     { $$ = std::make_unique<AST::IfStatement>(std::move($1)); }

--- a/src/frontend/parser.yy
+++ b/src/frontend/parser.yy
@@ -94,7 +94,8 @@
 
 %%
 
-program : statements                                { block = std::move($1); }
+program : %empty                                    { block = std::make_unique<AST::CodeBlock>(); }
+        | statements                                { block = std::move($1); }
         | statements "\n"                           { block = std::move($1); }
         ;
 

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -416,6 +416,13 @@ TEST(parser, foreach_statement_list) {
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::ForeachStatement>>(stmt));
 }
 
+TEST(parser, foreach_statement_dict) {
+    auto block = parse("foreach k, v : {a : 'b', b : 1}\na = b\ntarget()\nendforeach");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = block->statements[0];
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::ForeachStatement>>(stmt));
+}
+
 TEST(parser, break_statement) {
     auto block = parse("break");
     ASSERT_EQ(block->statements.size(), 1);

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -307,6 +307,7 @@ INSTANTIATE_TEST_CASE_P(DictParsingTests, DictToStringTests,
                                           std::make_tuple("{a : b, }", "{a : b}"),
                                           std::make_tuple("{a : b}", "{a : b}"),
                                           std::make_tuple("{'a' : 'b'}", "{'a' : 'b'}"),
+                                          std::make_tuple("{'a' : func()}", "{'a' : func()}"),
                                           std::make_tuple("{a : [b]}", "{a : [b]}")));
 // We can't test a multi item dict reliably like this be
 // cause meson dicts are unordered
@@ -403,6 +404,13 @@ TEST(IfStatementParsingTests, back_to_back_if_statments) {
 
 TEST(parser, foreach_statement) {
     auto block = parse("foreach x : a\na = b\ntarget()\nendforeach");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = block->statements[0];
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::ForeachStatement>>(stmt));
+}
+
+TEST(parser, foreach_statement_list) {
+    auto block = parse("foreach x : ['a', 'b']\na = b\ntarget()\nendforeach");
     ASSERT_EQ(block->statements.size(), 1);
     auto const & stmt = block->statements[0];
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::ForeachStatement>>(stmt));

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -401,16 +401,24 @@ TEST(parser, newline_in_statements) {
 }
 
 TEST(parser, comment_no_newline) {
-    auto block = parse("  # foo");
-    ASSERT_EQ(block->statements.size(), 0);
+    auto block = parse("a = 1\n  # foo");
+    ASSERT_EQ(block->statements.size(), 1);
 }
 
 TEST(parser, comment) {
-    auto block = parse("  # foo\n");
-    ASSERT_EQ(block->statements.size(), 0);
+    auto block = parse("a = 1\n  # foo\n");
+    ASSERT_EQ(block->statements.size(), 1);
 }
 
 TEST(parser, inline_comment) {
     auto block = parse("a = b  # foo\n");
     ASSERT_EQ(block->statements.size(), 1);
 }
+
+#if false
+// This fails because there is nothing in it, I don't understand why
+TEST(parser, empty) {
+    auto block = parse("# This file has no statmements\n  # or exepressions.");
+    ASSERT_EQ(block->statements.size(), 0);
+}
+#endif

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -462,6 +462,16 @@ TEST(parser, comment) {
     ASSERT_EQ(block->statements.size(), 1);
 }
 
+TEST(parser, comment2) {
+    auto block = parse("a = 1\n  # foo\nb = 2\n");
+    ASSERT_EQ(block->statements.size(), 2);
+}
+
+TEST(parser, comment_in_if) {
+    auto block = parse("if true\n  # comment\n  a = 2\nendif");
+    ASSERT_EQ(block->statements.size(), 1);
+}
+
 TEST(parser, inline_comment) {
     auto block = parse("a = b  # foo\n");
     ASSERT_EQ(block->statements.size(), 1);

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -402,6 +402,11 @@ TEST(IfStatementParsingTests, back_to_back_if_statments) {
     ASSERT_EQ(block->statements.size(), 2);
 }
 
+TEST(IfStatementParsingTests, backslash) {
+    auto block = parse("if true\\\n  or false\na = 1\nendif\nif false\nb = 2\nendif\n");
+    ASSERT_EQ(block->statements.size(), 2);
+}
+
 TEST(parser, foreach_statement) {
     auto block = parse("foreach x : a\na = b\ntarget()\nendforeach");
     ASSERT_EQ(block->statements.size(), 1);

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -487,10 +487,7 @@ TEST(parser, multiple_newlines) {
     ASSERT_EQ(block->statements.size(), 2);
 }
 
-#if false
-// This fails because there is nothing in it, I don't understand why
 TEST(parser, empty) {
     auto block = parse("# This file has no statmements\n  # or exepressions.");
     ASSERT_EQ(block->statements.size(), 0);
 }
-#endif

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -447,6 +447,16 @@ TEST(parser, inline_comment) {
     ASSERT_EQ(block->statements.size(), 1);
 }
 
+TEST(parser, inline_comment2) {
+    auto block = parse("a = b  # foo\nb = 2");
+    ASSERT_EQ(block->statements.size(), 2);
+}
+
+TEST(parser, multiple_newlines) {
+    auto block = parse("a = b\n\n\nb = 2");
+    ASSERT_EQ(block->statements.size(), 2);
+}
+
 #if false
 // This fails because there is nothing in it, I don't understand why
 TEST(parser, empty) {

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -25,6 +25,38 @@ TEST(parser, string) {
     ASSERT_EQ(stmt->as_string(), "'foo'");
 }
 
+TEST(parser, escape_in_string) {
+    auto block = parse("'can\\'t'");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::String>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "'can't'");
+}
+
+TEST(parser, newline_in_string) {
+    auto block = parse("'can\\'t\\nstop'");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::String>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "'can't\nstop'");
+}
+
+TEST(parser, tab_in_string) {
+    auto block = parse("'\\ttab'");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::String>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "'\ttab'");
+}
+
+TEST(parser, backslash_in_string) {
+    auto block = parse("'\\\\tab'");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::String>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "'\\tab'");
+}
+
 TEST(parser, triple_string) {
     auto block = parse("'''foo'''");
     ASSERT_EQ(block->statements.size(), 1);


### PR DESCRIPTION
The biggest change here is that we actually check the return value of the lexer and parser, which means that a number of things that were invalid are now actual errors.

I've also fixed a number of issues that I discovered by running most of the meson.build files from the main meson repo through the standalone parser:
* escape sequences in strings (but not triple strings yet)
* foreach loops with dictoinaries
* incorrect counting of lines
* using backslash to escape a newline 