### PR TITLE
Fix remaining parser issues for meson repo

### DIFF
--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -122,8 +122,8 @@ f'                              {
                                     BEGIN(INITIAL);
                                     return token::TSTRING;
                                 }
-0x[0-9a-fA-F]+                  { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 16)); return token::HEX_NUMBER; }
-0o[0-7]+                        { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 8)); return token::OCTAL_NUMBER; }
+0[xX][0-9a-fA-F]+               { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 16)); return token::HEX_NUMBER; }
+0[oO][0-7]+                     { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 8)); return token::OCTAL_NUMBER; }
 [0-9]+                          { lval->build<int64_t>(std::stoll(yytext)); return token::DECIMAL_NUMBER; }
 \-                              { return token::SUB; }
 \+                              { return token::ADD; }

--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -72,7 +72,12 @@ static std::string strbuffer{};
                                     if (!brace()) { return token::NEWLINE; }
                                 }
 (true|false)                    { lval->build<bool>(std::string(yytext) == "true"); return token::BOOL; }
-(>=|==|!=|<=|>|<|and|or|in|not\ in) { lval->build<std::string>(yytext); return token::RELATIONAL; }
+(>=|==|!=|<=|>|<|and|or|in)     { lval->build<std::string>(yytext); return token::RELATIONAL; }
+not\ in\                        {
+                                    std::string str{yytext};
+                                    lval->build<std::string>(str.substr(0, str.size() - 1));
+                                    return token::RELATIONAL;
+                                }
 not                             { return token::NOT; }
 if                              { return token::IF; }
 elif                            { return token::ELIF; }

--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -122,10 +122,10 @@ f'                              {
                                     BEGIN(INITIAL);
                                     return token::TSTRING;
                                 }
-0[xX][0-9a-fA-F]+               { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 16)); return token::HEX_NUMBER; }
-0[oO][0-7]+                     { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 8)); return token::OCTAL_NUMBER; }
-0[bB][0-1]+                     { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 2)); return token::BINARY_NUMBER; }
-[0-9]+                          { lval->build<int64_t>(std::stoll(yytext)); return token::DECIMAL_NUMBER; }
+0[xX][0-9a-fA-F]+               { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 16)); return token::NUMBER; }
+0[oO][0-7]+                     { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 8)); return token::NUMBER; }
+0[bB][0-1]+                     { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 2)); return token::NUMBER; }
+[0-9]+                          { lval->build<int64_t>(std::stoll(yytext)); return token::NUMBER; }
 \-                              { return token::SUB; }
 \+                              { return token::ADD; }
 \*                              { return token::MUL; }

--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -124,6 +124,7 @@ f'                              {
                                 }
 0[xX][0-9a-fA-F]+               { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 16)); return token::HEX_NUMBER; }
 0[oO][0-7]+                     { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 8)); return token::OCTAL_NUMBER; }
+0[bB][0-1]+                     { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 2)); return token::BINARY_NUMBER; }
 [0-9]+                          { lval->build<int64_t>(std::stoll(yytext)); return token::DECIMAL_NUMBER; }
 \-                              { return token::SUB; }
 \+                              { return token::ADD; }

--- a/src/frontend/lexer.l
+++ b/src/frontend/lexer.l
@@ -50,6 +50,7 @@ static std::string strbuffer{};
 
 %x STRING_STATE
 %x FSTRING_STATE
+%x TSTRING_STATE
 %%
 
     /* This is gross, but this is more working around how annoying newlines are in meson */
@@ -82,7 +83,11 @@ endforeach                      { return token::ENDFOREACH; }
 break                           { return token::BREAK; }
 continue                        { return token::CONTINUE; }
 [a-zA-Z_][a-zA-Z0-9_]*          { lval->build<std::string>(yytext); return token::IDENTIFIER; }
-[']{3}([']{0,2}([^\\']|\\(.|\n)))*[']{3} { lval->build<std::string>(yytext); return token::TSTRING; }
+[']{3}                          {
+                                    BEGIN(TSTRING_STATE);
+                                    strbuffer.clear();
+                                    strbuffer.append(yytext);
+                                }
 \'                              {
                                     BEGIN(STRING_STATE);
                                     strbuffer.clear();
@@ -93,11 +98,12 @@ f'                              {
                                     strbuffer.clear();
                                     strbuffer.append(yytext);
                                 }
-<STRING_STATE,FSTRING_STATE>\\'   { strbuffer.append("'"); }
-<STRING_STATE,FSTRING_STATE>\\n   { strbuffer.append("\n"); }
-<STRING_STATE,FSTRING_STATE>\\t   { strbuffer.append("\t"); }
-<STRING_STATE,FSTRING_STATE>\\\\  { strbuffer.append("\\"); }
+<STRING_STATE,FSTRING_STATE,TSTRING_STATE>\\'   { strbuffer.append("'"); }
+<STRING_STATE,FSTRING_STATE,TSTRING_STATE>\\n   { strbuffer.append("\n"); }
+<STRING_STATE,FSTRING_STATE,TSTRING_STATE>\\t   { strbuffer.append("\t"); }
+<STRING_STATE,FSTRING_STATE,TSTRING_STATE>\\\\  { strbuffer.append("\\"); }
 <STRING_STATE,FSTRING_STATE>[^']  { strbuffer.append(yytext); }
+<TSTRING_STATE>[^''']           { strbuffer.append(yytext); }
 <STRING_STATE>\'                {
                                     strbuffer.append(yytext);
                                     lval->build<std::string>(strbuffer);
@@ -109,6 +115,12 @@ f'                              {
                                     lval->build<std::string>(strbuffer);
                                     BEGIN(INITIAL);
                                     return token::FSTRING;
+                                }
+<TSTRING_STATE>[']{3}           {
+                                    strbuffer.append(yytext);
+                                    lval->build<std::string>(strbuffer);
+                                    BEGIN(INITIAL);
+                                    return token::TSTRING;
                                 }
 0x[0-9a-fA-F]+                  { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 16)); return token::HEX_NUMBER; }
 0o[0-7]+                        { lval->build<int64_t>(std::stoll(std::string{yytext}.substr(2), nullptr, 8)); return token::OCTAL_NUMBER; }

--- a/src/frontend/parser.yy
+++ b/src/frontend/parser.yy
@@ -43,7 +43,7 @@
 %define parse.assert
 
 %token <std::string>    IDENTIFIER TSTRING STRING FSTRING RELATIONAL
-%token <int64_t>        DECIMAL_NUMBER OCTAL_NUMBER HEX_NUMBER
+%token <int64_t>        DECIMAL_NUMBER OCTAL_NUMBER HEX_NUMBER BINARY_NUMBER
 %token <bool>           BOOL
 %token <AST::AssignOp>  ASSIGN
 %token                  LBRACKET            "["
@@ -188,6 +188,7 @@ keyword_item : expression ":" expression            { $$ = AST::KeywordPair(std:
 literal : HEX_NUMBER                                { $$ = AST::ExpressionV(std::make_unique<AST::Number>($1, @$)); }
         | DECIMAL_NUMBER                            { $$ = AST::ExpressionV(std::make_unique<AST::Number>($1, @$)); }
         | OCTAL_NUMBER                              { $$ = AST::ExpressionV(std::make_unique<AST::Number>($1, @$)); }
+        | BINARY_NUMBER                             { $$ = AST::ExpressionV(std::make_unique<AST::Number>($1, @$)); }
         | STRING                                    { $$ = AST::ExpressionV(std::make_unique<AST::String>($1.substr(1, $1.size() - 2), false, false, @$)); }
         | FSTRING                                   { $$ = AST::ExpressionV(std::make_unique<AST::String>($1.substr(1, $1.size() - 2), false, true, @$)); }
         | TSTRING                                   { $$ = AST::ExpressionV(std::make_unique<AST::String>($1.substr(3, $1.size() - 6), true, false, @$)); }

--- a/src/frontend/parser.yy
+++ b/src/frontend/parser.yy
@@ -43,7 +43,7 @@
 %define parse.assert
 
 %token <std::string>    IDENTIFIER TSTRING STRING FSTRING RELATIONAL
-%token <int64_t>        DECIMAL_NUMBER OCTAL_NUMBER HEX_NUMBER BINARY_NUMBER
+%token <int64_t>        NUMBER
 %token <bool>           BOOL
 %token <AST::AssignOp>  ASSIGN
 %token                  LBRACKET            "["
@@ -185,10 +185,7 @@ keyword_arguments : keyword_item                                { $$ = AST::Keyw
 keyword_item : expression ":" expression            { $$ = AST::KeywordPair(std::move($1), std::move($3)); }
              ;
 
-literal : HEX_NUMBER                                { $$ = AST::ExpressionV(std::make_unique<AST::Number>($1, @$)); }
-        | DECIMAL_NUMBER                            { $$ = AST::ExpressionV(std::make_unique<AST::Number>($1, @$)); }
-        | OCTAL_NUMBER                              { $$ = AST::ExpressionV(std::make_unique<AST::Number>($1, @$)); }
-        | BINARY_NUMBER                             { $$ = AST::ExpressionV(std::make_unique<AST::Number>($1, @$)); }
+literal : NUMBER                                    { $$ = AST::ExpressionV(std::make_unique<AST::Number>($1, @$)); }
         | STRING                                    { $$ = AST::ExpressionV(std::make_unique<AST::String>($1.substr(1, $1.size() - 2), false, false, @$)); }
         | FSTRING                                   { $$ = AST::ExpressionV(std::make_unique<AST::String>($1.substr(1, $1.size() - 2), false, true, @$)); }
         | TSTRING                                   { $$ = AST::ExpressionV(std::make_unique<AST::String>($1.substr(3, $1.size() - 6), true, false, @$)); }

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -116,9 +116,24 @@ TEST(parser, octal_number) {
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::Number>>(stmt->expr));
     ASSERT_EQ(stmt->as_string(), "8");
 }
+TEST(parser, octal_number2) {
+    auto block = parse("0O10");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::Number>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "8");
+}
 
 TEST(parser, hex_number) {
     auto block = parse("0xf");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::Number>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "15");
+}
+
+TEST(parser, hex_number2) {
+    auto block = parse("0XF");
     ASSERT_EQ(block->statements.size(), 1);
     auto const & stmt = std::get<0>(block->statements[0]);
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::Number>>(stmt->expr));

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -140,6 +140,22 @@ TEST(parser, hex_number2) {
     ASSERT_EQ(stmt->as_string(), "15");
 }
 
+TEST(parser, binary_number) {
+    auto block = parse("0b1101");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::Number>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "13");
+}
+
+TEST(parser, binary_number2) {
+    auto block = parse("0B1100");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::Number>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "12");
+}
+
 TEST(parser, identifier) {
     auto block = parse("foo");
     ASSERT_EQ(block->statements.size(), 1);

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -73,6 +73,22 @@ TEST(parser, triple_string_newlines) {
     ASSERT_EQ(stmt->as_string(), "'''\nfoo\n\nbar'''");
 }
 
+TEST(parser, triple_string_escaped_newlines) {
+    auto block = parse("'''\nfoo\n\\nbar'''");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::String>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "'''\nfoo\n\nbar'''");
+}
+
+TEST(parser, triple_string_escapes) {
+    auto block = parse("'''foo\\t\\\\tab'''");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<Frontend::AST::String>>(stmt->expr));
+    ASSERT_EQ(stmt->as_string(), "'''foo\t\\tab'''");
+}
+
 TEST(parser, decminal_number) {
     auto block = parse("77");
     ASSERT_EQ(block->statements.size(), 1);

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -227,6 +227,15 @@ TEST(parser, unary_not) {
     ASSERT_EQ(block->as_string(), "not true");
 }
 
+TEST(parser, unary_not_not) {
+    auto block = parse("not not true");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(
+        std::holds_alternative<std::unique_ptr<Frontend::AST::UnaryExpression>>(stmt->expr));
+    ASSERT_EQ(block->as_string(), "not not true");
+}
+
 TEST(parser, subscript) {
     auto block = parse("foo[bar + 1]");
     ASSERT_EQ(block->statements.size(), 1);

--- a/src/frontend/parser_test.cpp
+++ b/src/frontend/parser_test.cpp
@@ -236,6 +236,24 @@ TEST(parser, unary_not_not) {
     ASSERT_EQ(block->as_string(), "not not true");
 }
 
+TEST(parser, not_in_false_positive) {
+    auto block = parse("not int");
+    ASSERT_EQ(block->statements.size(), 1);
+    auto const & stmt = std::get<0>(block->statements[0]);
+    ASSERT_TRUE(
+        std::holds_alternative<std::unique_ptr<Frontend::AST::UnaryExpression>>(stmt->expr));
+    ASSERT_EQ(block->as_string(), "not int");
+}
+
+TEST(parser, not_func_call) {
+    auto block = parse("not meson.func()");
+    // ASSERT_EQ(block->statements.size(), 1);
+    // auto const & stmt = std::get<0>(block->statements[0]);
+    // ASSERT_TRUE(
+    //     std::holds_alternative<std::unique_ptr<Frontend::AST::UnaryExpression>>(stmt->expr));
+    // ASSERT_EQ(block->as_string(), "not not true");
+}
+
 TEST(parser, subscript) {
     auto block = parse("foo[bar + 1]");
     ASSERT_EQ(block->statements.size(), 1);


### PR DESCRIPTION
With this the meson++ parser can correctly parse all of the meson.build files in the main meson repo that are supposed to be parsed (there are some that are supposed to fail).

Fixes #34 