### PR TITLE
Fixups for the meson++ command line parser

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -108,6 +108,12 @@ ConfigureOptions get_config_options(int argc, char * argv[]) {
         exit(1);
     }
     conf.builddir = fs::path{argv[i++]};
+    if (i < argc) {
+        // TODO: better error message
+        std::cerr << "Got extra arguments." << std::endl;
+        std::cout << usage << std::endl;
+        exit(1);
+    }
 
     return conf;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -34,6 +34,8 @@ Verbs:
         Options:
             -h, --help
                 Display this message and exit.
+            -s, --source-dir
+                The source directory to configure, defaults to '.'
             -D, --define
                 Set a Meson built-in or project option
 
@@ -61,7 +63,7 @@ ConfigureOptions get_config_options(int argc, char * argv[]) {
     static const char * const short_opts = "hs:D:";
     static const option long_opts[] = {
         {"help", no_argument, NULL, 'h'},
-        {"source_dir", required_argument, NULL, 's'},
+        {"source-dir", required_argument, NULL, 's'},
         {"define", required_argument, NULL, 'D'},
         {NULL},
     };


### PR DESCRIPTION
* handle extra positional arguments (an error)
* document the --source-dir argument