### PR TITLE
Rework if lowering from ast

### DIFF
--- a/src/mir/ast_to_mir.cpp
+++ b/src/mir/ast_to_mir.cpp
@@ -156,6 +156,8 @@ struct StatementLowering {
         // This is the block that all exists from the conditional web will flow
         // back into if they don't exit. I think this is safe even for cases where
         // The blocks don't really rejoin, as this will just be empty and that's fine.
+        //
+        // This has the added bonus of giving us a place to put phi nodes?
         auto next_block = std::make_shared<BasicBlock>();
 
         // The last block that was encountered, we need this to add the next block to it.

--- a/src/mir/ast_to_mir.cpp
+++ b/src/mir/ast_to_mir.cpp
@@ -217,6 +217,30 @@ struct StatementLowering {
             assert(last_block->condition == nullptr);
             assert(last_block->next == nullptr);
             last_block->next = next_block;
+        } else {
+            /*
+             * Codegen time!
+             * If we're here that means we have the following situation:
+             *   <block 1>
+             *   if condition
+             *     <block 2>
+             *   endif
+             *   <block 3>
+             * Which means that if condition is false, that we need <block 1>
+             * continue to <block 2>. To achieve that we create an else block
+             * which continnues on, ie:
+             *   <block 1>
+             *   if condition
+             *     <block 2>
+             *   else
+             *     <block 3>
+             *   endif
+             *   <block 4>
+             *
+             * By treating all if's as having an else block we simplify our handling considerably.
+             */
+            cur->if_false =
+                std::make_unique<Condition>(std::make_unique<Boolean>(true), next_block);
         }
 
         // The last leg of the tree should be empty

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -9,6 +9,9 @@ namespace MIR {
 Condition::Condition(Object && o)
     : condition{std::move(o)}, if_true{std::make_shared<BasicBlock>()}, if_false{nullptr} {};
 
+Condition::Condition(Object && o, std::shared_ptr<BasicBlock> s)
+    : condition{std::move(o)}, if_true{s}, if_false{nullptr} {};
+
 const Object Compiler::get_id(const std::vector<Object> & args,
                               const std::unordered_map<std::string, Object> & kwargs) const {
     if (!args.empty()) {

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -7,7 +7,7 @@
 namespace MIR {
 
 Condition::Condition(Object && o)
-    : condition{std::move(o)}, if_true{std::make_unique<BasicBlock>()}, if_false{nullptr} {};
+    : condition{std::move(o)}, if_true{std::make_shared<BasicBlock>()}, if_false{nullptr} {};
 
 const Object Compiler::get_id(const std::vector<Object> & args,
                               const std::unordered_map<std::string, Object> & kwargs) const {

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -6,6 +6,9 @@
 
 namespace MIR {
 
+Condition::Condition(Object && o)
+    : condition{std::move(o)}, if_true{std::make_unique<BasicBlock>()}, if_false{nullptr} {};
+
 const Object Compiler::get_id(const std::vector<Object> & args,
                               const std::unordered_map<std::string, Object> & kwargs) const {
     if (!args.empty()) {

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -225,6 +225,7 @@ class BasicBlock;
 class Condition {
   public:
     Condition(Object && o);
+    Condition(Object && o, std::shared_ptr<BasicBlock> s);
 
     /// An object that is the condition
     Object condition;

--- a/src/mir/passes/compilers.cpp
+++ b/src/mir/passes/compilers.cpp
@@ -26,7 +26,7 @@ std::optional<Object> replace_compiler(const Object & obj, const ToolchainMap & 
         return std::nullopt;
     }
 
-    if (f->holder.value_or("") != "meson" && f->name != "get_compiler") {
+    if (f->holder.value_or("") != "meson" || f->name != "get_compiler") {
         return std::nullopt;
     }
 

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -7,7 +7,7 @@ namespace MIR::Passes {
 
 bool join_blocks(BasicBlock * block) {
     // If there is a condition we can't join this block to the next one
-    if (block->condition.has_value()) {
+    if (block->condition != nullptr) {
         return false;
     }
 
@@ -19,7 +19,7 @@ bool join_blocks(BasicBlock * block) {
     // Move the instructions of the next block into this one, then the condition
     // if neceissry, then make the next block the next->next block.
     block->instructions.splice(block->instructions.end(), block->next->instructions);
-    if (block->next->condition.has_value()) {
+    if (block->next->condition != nullptr) {
         block->condition = std::move(block->next->condition);
     }
     block->next = block->next->next;

--- a/src/mir/passes/pruning.cpp
+++ b/src/mir/passes/pruning.cpp
@@ -15,13 +15,12 @@ bool branch_pruning(BasicBlock * ir) {
         return false;
     }
 
+    // Set the true condition to the true branch, then let join_branches worry
+    // about cleaning up.
     const bool & con_v = std::get<std::unique_ptr<Boolean>>(con.condition)->value;
     auto new_v = con_v ? con.if_true : con.if_false;
-    ir->instructions.splice(ir->instructions.end(), new_v->instructions);
-    // Always do this, as the new_v condition could be empty, and we ant that as
-    // well.
-    ir->condition = std::move(new_v->condition);
-    ir->next = new_v->next;
+    ir->next = new_v;
+    ir->condition = std::nullopt;
 
     return true;
 };

--- a/src/mir/passes/pruning.cpp
+++ b/src/mir/passes/pruning.cpp
@@ -6,21 +6,26 @@
 namespace MIR::Passes {
 
 bool branch_pruning(BasicBlock * ir) {
-    if (!ir->condition.has_value()) {
+    if (ir->condition == nullptr) {
         return false;
     }
 
-    const auto & con = ir->condition.value();
-    if (!std::holds_alternative<std::unique_ptr<Boolean>>(con.condition)) {
+    const auto & con = ir->condition;
+    if (!std::holds_alternative<std::unique_ptr<Boolean>>(con->condition)) {
         return false;
     }
 
-    // Set the true condition to the true branch, then let join_branches worry
-    // about cleaning up.
-    const bool & con_v = std::get<std::unique_ptr<Boolean>>(con.condition)->value;
-    auto new_v = con_v ? con.if_true : con.if_false;
-    ir->next = new_v;
-    ir->condition = std::nullopt;
+    // If the true branch is the one we want, move the next and condition to our
+    // next and condition, otherwise move the `else` branch to be the main condition, and continue
+    const bool & con_v = std::get<std::unique_ptr<Boolean>>(con->condition)->value;
+    if (con_v) {
+        assert(con->if_true != nullptr);
+        ir->next = con->if_true;
+        ir->condition = nullptr;
+    } else if (con->if_false != nullptr) {
+        assert(ir->next == nullptr);
+        ir->condition = std::move(con->if_false);
+    }
 
     return true;
 };

--- a/src/mir/passes/walkers.cpp
+++ b/src/mir/passes/walkers.cpp
@@ -44,10 +44,12 @@ bool instruction_walker(BasicBlock * block, const std::vector<MutationCallback> 
                 progress |= true;
             }
         }
-        for (const auto & cb : fc) {
-            progress |= cb(*it);
-        }
         ++it;
+    }
+    for (const auto & cb : fc) {
+        for (auto & it : block->instructions) {
+            progress |= cb(it);
+        }
     }
 
     return progress;
@@ -106,11 +108,11 @@ bool function_walker(BasicBlock * block, const ReplacementCallback & cb) {
         {cb});
 
     // Check if we have a condition, and try to lower that as well.
-    if (block->condition.has_value()) {
-        auto & con = block->condition.value();
-        auto new_value = cb(con.condition);
+    if (block->condition != nullptr) {
+        auto & con = block->condition;
+        auto new_value = cb(con->condition);
         if (new_value.has_value()) {
-            con.condition = std::move(new_value.value());
+            con->condition = std::move(new_value.value());
             progress |= true;
         }
     }


### PR DESCRIPTION
The current way that if lowering is done is completely broken. For one thing, nested if's don't work. For another the entire value of the SSAish only two possible outputs isn't really true. This work makes the IR slightly more complicated but more consistent. I've also commented some code that I couldn't remember how it worked, and tried to leave more useful comments this time.