### PR TITLE
MIR: track blocks parents as well as their children

### DIFF
--- a/src/mir/ast_to_mir.cpp
+++ b/src/mir/ast_to_mir.cpp
@@ -172,6 +172,7 @@ struct StatementLowering {
         auto * cur = std::get<std::unique_ptr<Condition>>(list->next).get();
 
         last_block = cur->if_true.get();
+        last_block->parents.emplace(list);
 
         // Walk over the statements, adding them to the if_true branch.
         for (const auto & i : stmt->ifblock.block->statements) {
@@ -186,6 +187,7 @@ struct StatementLowering {
         // We shouldn't have a condition here, this is where we wnat to put our next target
         assert(std::holds_alternative<std::monostate>(last_block->next));
         last_block->next = next_block;
+        next_block->parents.emplace(last_block);
 
         // for each elif branch create a new condition in the `else` of the
         // Condition, then assign the condition to the `if_true`. Then go down
@@ -194,6 +196,7 @@ struct StatementLowering {
             for (const auto & el : stmt->efblock) {
                 cur->if_false = std::make_shared<BasicBlock>(
                     std::make_unique<Condition>(std::visit(l, el.condition)));
+                cur->if_false->parents.emplace(list);
                 cur = std::get<std::unique_ptr<Condition>>(cur->if_false->next).get();
                 last_block = cur->if_true.get();
 
@@ -202,8 +205,9 @@ struct StatementLowering {
                         [&](const auto & a) { return this->operator()(last_block, a); }, i);
                 }
 
-                assert(std::holds_alternative<std::monostate>(last_block->next));
+                assert(!std::holds_alternative<std::unique_ptr<Condition>>(last_block->next));
                 last_block->next = next_block;
+                next_block->parents.emplace(last_block);
             }
         }
 
@@ -212,18 +216,21 @@ struct StatementLowering {
             assert(cur->if_false == nullptr);
             cur->if_false = std::make_shared<BasicBlock>();
             last_block = cur->if_false.get();
+            last_block->parents.emplace(list);
             for (const auto & i : stmt->eblock.block->statements) {
                 last_block =
                     std::visit([&](const auto & a) { return this->operator()(last_block, a); }, i);
             }
-            assert(std::holds_alternative<std::monostate>(last_block->next));
+            assert(!std::holds_alternative<std::unique_ptr<Condition>>(last_block->next));
             last_block->next = next_block;
+            next_block->parents.emplace(last_block);
         } else {
             // If we don't have an else, create a false one by putting hte next
             // block in it. this means taht if we don't go down any of the
             // branches that we proceed on correctly
             assert(cur->if_false == nullptr);
             cur->if_false = next_block;
+            next_block->parents.emplace(list);
         }
 
         assert(std::holds_alternative<std::monostate>(next_block->next));

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -237,37 +237,22 @@ class Condition {
     std::shared_ptr<BasicBlock> if_false;
 };
 
+using NextType =
+    std::variant<std::monostate, std::unique_ptr<Condition>, std::shared_ptr<BasicBlock>>;
+
 /**
- * Holds a list of instructions, and optionally a condition or next point
- *
- * Jump is used when the list unconditionally jumps to another basic block, and
- * thus condition should be nullopt. This is meant for cases such as:
- *
- *       / 2 \
- * 0 - 1 - 3 - 4
- *
- *  In this case both 2 and 3 unconditionally continue to 4, but we don't want
- *  two copies of 4, just one, they both will "jump" to 4.
- *
- * On the other hand 1 does not make any unconditional jumps, and it uses the
- * condition node to set a condition as to whether it goes to 2 or 3.
- *
- * TOOD: maybe it's better to use a variant/union?
- *
+ * Holds a list of instructions, and optionally a condition or next block
  */
 class BasicBlock {
   public:
-    BasicBlock() : instructions{}, condition{nullptr}, next{nullptr} {};
-    BasicBlock(std::unique_ptr<Condition> && con) : instructions{}, condition{std::move(con)}, next{nullptr} {};
+    BasicBlock() : instructions{}, next{std::monostate{}} {};
+    BasicBlock(std::unique_ptr<Condition> && con) : instructions{}, next{std::move(con)} {};
 
     /// The instructions in this block
     std::list<Object> instructions;
 
-    /// A conditional output for this block
-    std::unique_ptr<Condition> condition;
-
-    /// The next basic block to go to.
-    std::shared_ptr<BasicBlock> next;
+    /// Either nothing, a pointer to another BasicBlock, or a pointer to a Condition
+    NextType next;
 };
 
 } // namespace MIR

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -16,6 +16,7 @@
 #include <list>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <sys/types.h>
 #include <unordered_map>
@@ -245,14 +246,18 @@ using NextType =
  */
 class BasicBlock {
   public:
-    BasicBlock() : instructions{}, next{std::monostate{}} {};
-    BasicBlock(std::unique_ptr<Condition> && con) : instructions{}, next{std::move(con)} {};
+    BasicBlock() : instructions{}, next{std::monostate{}}, parents{} {};
+    BasicBlock(std::unique_ptr<Condition> && con)
+        : instructions{}, next{std::move(con)}, parents{} {};
 
     /// The instructions in this block
     std::list<Object> instructions;
 
     /// Either nothing, a pointer to another BasicBlock, or a pointer to a Condition
     NextType next;
+
+    /// All potential parents of this block
+    std::set<BasicBlock *> parents;
 };
 
 } // namespace MIR

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -230,11 +230,11 @@ class Condition {
     /// An object that is the condition
     Object condition;
 
-    /// The branch to take if the condition is true
+    /// The block to go to if the condition is true
     std::shared_ptr<BasicBlock> if_true;
 
-    /// The branch to take if the condition is false
-    std::unique_ptr<Condition> if_false;
+    /// The block to go to if the condition is false
+    std::shared_ptr<BasicBlock> if_false;
 };
 
 /**
@@ -258,6 +258,7 @@ class Condition {
 class BasicBlock {
   public:
     BasicBlock() : instructions{}, condition{nullptr}, next{nullptr} {};
+    BasicBlock(std::unique_ptr<Condition> && con) : instructions{}, condition{std::move(con)}, next{nullptr} {};
 
     /// The instructions in this block
     std::list<Object> instructions;

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -13,6 +13,12 @@ bool join_blocks(BasicBlock * block) {
 
     auto & next = std::get<std::shared_ptr<BasicBlock>>(block->next);
 
+    // If the next block has more than one parent we can't join them yet,
+    // otherwise the other parent would end up with a pointer to an empty block
+    if (next->parents.size() > 1) {
+        return false;
+    }
+
     // Move the instructions of the next block into this one, then the condition
     // if neceissry, then make the next block the next->next block.
     block->instructions.splice(block->instructions.end(), next->instructions);

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -16,7 +16,8 @@ bool join_blocks(BasicBlock * block) {
     // Move the instructions of the next block into this one, then the condition
     // if neceissry, then make the next block the next->next block.
     block->instructions.splice(block->instructions.end(), next->instructions);
-    block->next = std::move(next->next);
+    auto nn = std::move(next->next);
+    block->next = std::move(nn);
 
     return true;
 }

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -6,23 +6,17 @@
 namespace MIR::Passes {
 
 bool join_blocks(BasicBlock * block) {
-    // If there is a condition we can't join this block to the next one
-    if (block->condition != nullptr) {
+    // If there isn't a next block, then we obviously can't do anything
+    if (!std::holds_alternative<std::shared_ptr<BasicBlock>>(block->next)) {
         return false;
     }
 
-    // If there isn't a next block, then we obviously can't do anything
-    if (block->next == nullptr) {
-        return false;
-    }
+    auto & next = std::get<std::shared_ptr<BasicBlock>>(block->next);
 
     // Move the instructions of the next block into this one, then the condition
     // if neceissry, then make the next block the next->next block.
-    block->instructions.splice(block->instructions.end(), block->next->instructions);
-    if (block->next->condition != nullptr) {
-        block->condition = std::move(block->next->condition);
-    }
-    block->next = block->next->next;
+    block->instructions.splice(block->instructions.end(), next->instructions);
+    block->next = std::move(next->next);
 
     return true;
 }

--- a/src/mir/passes/pruning.cpp
+++ b/src/mir/passes/pruning.cpp
@@ -1,6 +1,8 @@
 // SPDX-license-identifier: Apache-2.0
 // Copyright © 2021 Dylan Baker
 
+#include <algorithm>
+
 #include "passes.hpp"
 
 namespace MIR::Passes {
@@ -18,6 +20,9 @@ bool branch_pruning(BasicBlock * ir) {
         return false;
     }
 
+    // worklist for cleaning up
+    std::vector<BasicBlock *> todo{};
+
     // If the true branch is the one we want, move the next and condition to our
     // next and condition, otherwise move the `else` branch to be the main condition, and continue
     const bool & con_v = std::get<std::unique_ptr<Boolean>>(con->condition)->value;
@@ -25,10 +30,53 @@ bool branch_pruning(BasicBlock * ir) {
     if (con_v) {
         assert(con->if_true != nullptr);
         next = con->if_true;
+        todo.emplace_back(con->if_false.get());
     } else {
         assert(con->if_false != nullptr);
         next = con->if_false;
+        todo.emplace_back(con->if_true.get());
     }
+
+    // When we prune this, we need to all remove it from any successor blocks
+    // parents' so that we dont reference a dangling pointer
+
+    // Blocks that have already been visited
+    std::set<BasicBlock *> visited{};
+
+    // Walk down the CFG of the block we're about to prune until we find a block
+    // with parents that aren't visited or todo items, that is the convergance point
+    // Then remove this path from that block's parents.
+    while (!todo.empty()) {
+        auto * current = todo.back();
+        todo.pop_back();
+        visited.emplace(current);
+
+        // It is possible to put the last block onot the todo stack, just continue on
+        if (std::holds_alternative<std::monostate>(current->next)) {
+            continue;
+        }
+
+        // If we have a Condition then push the True block, then the False
+        // block, then loop back through
+        if (std::holds_alternative<std::unique_ptr<Condition>>(current->next)) {
+            const auto & con = std::get<std::unique_ptr<Condition>>(current->next);
+            todo.emplace_back(con->if_true.get());
+            todo.emplace_back(con->if_false.get());
+            continue;
+        }
+
+        auto bb = std::get<std::shared_ptr<BasicBlock>>(current->next);
+
+        auto parents = bb->parents;
+        for (const auto & p : parents) {
+            if (visited.count(p)) {
+                bb->parents.erase(p);
+            } else if (std::count(todo.begin(), todo.end(), p)) {
+                bb->parents.erase(p);
+            }
+        }
+    }
+
     ir->next = next;
 
     return true;

--- a/src/mir/passes/pruning.cpp
+++ b/src/mir/passes/pruning.cpp
@@ -21,11 +21,10 @@ bool branch_pruning(BasicBlock * ir) {
     if (con_v) {
         assert(con->if_true != nullptr);
         ir->next = con->if_true;
-        ir->condition = nullptr;
     } else if (con->if_false != nullptr) {
-        assert(ir->next == nullptr);
-        ir->condition = std::move(con->if_false);
+        ir->next = con->if_false;
     }
+    ir->condition = nullptr;
 
     return true;
 };

--- a/src/mir/passes/walkers.cpp
+++ b/src/mir/passes/walkers.cpp
@@ -108,8 +108,8 @@ bool function_walker(BasicBlock * block, const ReplacementCallback & cb) {
         {cb});
 
     // Check if we have a condition, and try to lower that as well.
-    if (block->condition != nullptr) {
-        auto & con = block->condition;
+    if (std::holds_alternative<std::unique_ptr<Condition>>(block->next)) {
+        auto & con = std::get<std::unique_ptr<Condition>>(block->next);
         auto new_value = cb(con->condition);
         if (new_value.has_value()) {
             con->condition = std::move(new_value.value());


### PR DESCRIPTION
This is necessary for cross block optimizations to work, especially branch joining. Without this the joining pass could easily try to join two blocks where the child has two parents. This is additionally helpful in allowing us to do reverse traversals of the IR