### PR TITLE
mir/passes/value_numbering: introduce

### DIFF
--- a/src/mir/lower.cpp
+++ b/src/mir/lower.cpp
@@ -1,6 +1,8 @@
 // SPDX-license-identifier: Apache-2.0
 // Copyright © 2021 Intel Corporation
 
+#include <unordered_map>
+
 #include "lower.hpp"
 #include "passes/private.hpp"
 
@@ -12,6 +14,8 @@ void lower(BasicBlock * block, State::Persistant & pstate) {
                                  return Passes::machine_lower(b, pstate.machines) ||
                                         Passes::insert_compilers(block, pstate.toolchains);
                              }});
+
+    std::unordered_map<std::string, uint32_t> value_number_data{};
 
     // clang-format off
     do {

--- a/src/mir/meson.build
+++ b/src/mir/meson.build
@@ -16,6 +16,7 @@ libmir = static_library(
     'passes/machines.cpp',
     'passes/pruning.cpp',
     'passes/walkers.cpp',
+    'passes/value_numbering.cpp',
     locations_hpp,
   ],
   include_directories : inc_frontend,

--- a/src/mir/passes.hpp
+++ b/src/mir/passes.hpp
@@ -76,4 +76,9 @@ bool lower_free_functions(BasicBlock *, const State::Persistant &);
  */
 bool flatten(BasicBlock *, const State::Persistant &);
 
+/**
+ * number each use of a variable
+ */
+bool value_numbering(BasicBlock *, std::unordered_map<std::string, uint32_t> &);
+
 } // namespace MIR::Passes

--- a/src/mir/passes/value_numbering.cpp
+++ b/src/mir/passes/value_numbering.cpp
@@ -1,0 +1,37 @@
+// SPDX-license-identifier: Apache-2.0
+// Copyright © 2021 Dylan Baker
+
+#include "passes.hpp"
+#include "private.hpp"
+
+namespace MIR::Passes {
+
+namespace {
+
+bool number(Object & obj, std::unordered_map<std::string, uint32_t> & data) {
+    Variable * var = std::visit([](auto & obj) { return &obj->var; }, obj);
+    if (!var) {
+        return false;
+    }
+
+    // We'll visit the same block twice
+    if (var->version > 0) {
+        return false;
+    }
+
+    if (data.count(var->name) == 0) {
+        data[var->name] = 0;
+    }
+
+    var->version = ++data[var->name];
+
+    return true;
+}
+
+} // namespace
+
+bool value_numbering(BasicBlock * block, std::unordered_map<std::string, uint32_t> & data) {
+    return instruction_walker(block, {[&](Object & obj) { return number(obj, data); }});
+}
+
+} // namespace MIR::Passes

--- a/src/mir/passes/walkers.cpp
+++ b/src/mir/passes/walkers.cpp
@@ -138,9 +138,7 @@ bool block_walker(BasicBlock * root, const std::vector<BlockWalkerCb> & callback
             for (const auto & cb : callbacks) {
                 lprogress = cb(current);
             }
-            if (lprogress) {
-                progress = true;
-            }
+            progress |= lprogress;
         }
 
         if (std::holds_alternative<std::unique_ptr<Condition>>(current->next)) {


### PR DESCRIPTION
This adds a value numbering pass. All it does is go through and
annotations for which "version" of the variable this is. This doesn't
re-value something that's already been valued. Taht might prove to be
annoying, but I'm going to go with it for now.

If we do need to re-value, we probably need to write a "de-numbering"
pass to run before the value_numbering pass, due to revisiting the same
block twice.

Fixes #29