### PR TITLE
mir/passes: don't visit blocks twice with BlockWalker

### DIFF
--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -5,7 +5,9 @@
 
 namespace MIR::Passes {
 
-bool join_blocks(BasicBlock * block) {
+namespace {
+
+bool join_blocks_impl(BasicBlock * block) {
     // If there isn't a next block, then we obviously can't do anything
     if (!std::holds_alternative<std::shared_ptr<BasicBlock>>(block->next)) {
         return false;
@@ -26,6 +28,23 @@ bool join_blocks(BasicBlock * block) {
     block->next = std::move(nn);
 
     return true;
+}
+
+} // namespace
+
+bool join_blocks(BasicBlock * block) {
+    bool progress = false;
+    bool lprogress;
+
+    // Run this on the same block as long as it's making progress. We do this so
+    // that if the new next block can also be pruned we do that with few
+    // iterations.
+    do {
+        lprogress = join_blocks_impl(block);
+        progress |= lprogress;
+    } while (lprogress);
+
+    return progress;
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/pruning.cpp
+++ b/src/mir/passes/pruning.cpp
@@ -7,7 +7,9 @@
 
 namespace MIR::Passes {
 
-bool branch_pruning(BasicBlock * ir) {
+namespace {
+
+bool branch_pruning_impl(BasicBlock * ir) {
     // If we don't have a condition there's nothing to do
     if (!std::holds_alternative<std::unique_ptr<Condition>>(ir->next)) {
         return false;
@@ -81,5 +83,22 @@ bool branch_pruning(BasicBlock * ir) {
 
     return true;
 };
+
+} // namespace
+
+bool branch_pruning(BasicBlock * block) {
+    bool progress = false;
+    bool lprogress;
+
+    // Run this on the same block as long as it's making progress. We do this so
+    // that if the new next block can also be pruned we do that with few
+    // iterations.
+    do {
+        lprogress = branch_pruning_impl(block);
+        progress |= lprogress;
+    } while (lprogress);
+
+    return progress;
+}
 
 } // namespace MIR::Passes

--- a/src/mir/passes/value_numbering.cpp
+++ b/src/mir/passes/value_numbering.cpp
@@ -14,11 +14,6 @@ bool number(Object & obj, std::unordered_map<std::string, uint32_t> & data) {
         return false;
     }
 
-    // We'll visit the same block twice
-    if (var->version > 0) {
-        return false;
-    }
-
     if (data.count(var->name) == 0) {
         data[var->name] = 0;
     }

--- a/src/mir/passes/walkers.cpp
+++ b/src/mir/passes/walkers.cpp
@@ -133,12 +133,8 @@ bool block_walker(BasicBlock * root, const std::vector<BlockWalkerCb> & callback
         // It's possible that we need to walk over the same block twice in a
         // loop because the block has been mutated such that running the same
         // test on it will result in a different result.
-        bool lprogress = true;
-        while (lprogress) {
-            for (const auto & cb : callbacks) {
-                lprogress = cb(current);
-            }
-            progress |= lprogress;
+        for (const auto & cb : callbacks) {
+            progress |= cb(current);
         }
 
         if (std::holds_alternative<std::unique_ptr<Condition>>(current->next)) {


### PR DESCRIPTION
This seemed like a good idea at the time, but it wasn't. Instead passes
that want to act on the same block multiple times should just do that
internally. This ports both branch_pruning and join_blocks to work this
way.

Fixes #55