### PR TITLE
Implement the message() family of functions

### DIFF
--- a/src/mir/meson/meson.build
+++ b/src/mir/meson/meson.build
@@ -15,6 +15,7 @@ libmeson = static_library(
     'machines.cpp',
     'objects/file.cpp',
     'objects/include_directories.cpp',
+    'state/state.cpp',
     'toolchains/archivers/gnu.cpp',
     'toolchains/common.cpp',
     'toolchains/compilers/cpp/clang.cpp',

--- a/src/mir/meson/state/state.cpp
+++ b/src/mir/meson/state/state.cpp
@@ -1,0 +1,11 @@
+// SPDX-license-identifier: Apache-2.0
+// Copyright © 2021-2022 Dylan Baker
+
+#include "state.hpp"
+
+namespace MIR::State {
+
+Persistant::Persistant(const std::filesystem::path & sr_, const std::filesystem::path & br_)
+    : toolchains{}, machines{Machines::detect_build()}, source_root{sr_}, build_root{br_} {};
+
+}

--- a/src/mir/meson/state/state.hpp
+++ b/src/mir/meson/state/state.hpp
@@ -18,9 +18,7 @@ namespace MIR::State {
  */
 class Persistant {
   public:
-    Persistant(const std::filesystem::path & sr_, const std::filesystem::path & br_)
-        : toolchains{}, machines{Machines::detect_build()}, source_root{sr_}, build_root{br_} {};
-    ~Persistant(){};
+    Persistant(const std::filesystem::path &, const std::filesystem::path &);
 
     // This must be mutable because of `add_language`
     /// A mapping of language : machine : toolchain

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -105,6 +105,26 @@ class IncludeDirectories {
     Variable var;
 };
 
+enum class MessageLevel {
+    DEBUG,
+    MESSAGE,
+    WARN,
+    ERROR,
+};
+
+class Message {
+  public:
+    Message(const MessageLevel & l, const std::string & m) : level{l}, message{m} {};
+
+    /// What level or kind of message this is
+    const MessageLevel level;
+
+    /// The message itself
+    const std::string message;
+
+    Variable var;
+};
+
 /*
  * Thse objects "Wrap" a lower level object, and provide interfaces for user
  * defined data. Their main job is to take the user data, validate it, and call
@@ -125,7 +145,7 @@ using Object =
                  std::shared_ptr<Number>, std::unique_ptr<Identifier>, std::shared_ptr<Array>,
                  std::shared_ptr<Dict>, std::shared_ptr<Compiler>, std::shared_ptr<File>,
                  std::shared_ptr<Executable>, std::shared_ptr<StaticLibrary>, std::unique_ptr<Phi>,
-                 std::shared_ptr<IncludeDirectories>>;
+                 std::shared_ptr<IncludeDirectories>, std::unique_ptr<Message>>;
 
 /**
  * Holds a toolchain

--- a/src/mir/passes/flatten.cpp
+++ b/src/mir/passes/flatten.cpp
@@ -32,7 +32,7 @@ std::optional<Object> flatten_cb(const Object & obj) {
     std::vector<Object> newarr{};
     do_flatten(arr, newarr);
 
-    return std::make_unique<Array>(std::move(newarr));
+    return std::make_shared<Array>(std::move(newarr));
 }
 
 } // namespace

--- a/src/mir/passes/private.hpp
+++ b/src/mir/passes/private.hpp
@@ -62,7 +62,22 @@ template <typename T> std::optional<T> extract_positional_argument(const Object 
     if (std::holds_alternative<T>(arg)) {
         return std::get<T>(arg);
     }
+    // TODO: this ignores invalid arguments
     return std::nullopt;
+}
+
+template <typename T>
+std::vector<T> extract_variadic_arguments(std::vector<Object>::iterator start,
+                                          std::vector<Object>::iterator end) {
+    std::vector<T> nobjs{};
+    for (; start != end; start++) {
+        // TODO: this is going to ignore invalid arghuments
+        std::optional<T> arg = extract_positional_argument<T>(*start);
+        if (arg) {
+            nobjs.emplace_back(arg.value());
+        }
+    }
+    return nobjs;
 }
 
 template <typename T>

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -17,6 +17,8 @@ std::string green(const std::string & s) { return "\033[32m" + s + RESET; };
 
 std::string red(const std::string & s) { return "\033[31m" + s + RESET; };
 
+std::string yellow(const std::string & s) { return "\033[33m" + s + RESET; };
+
 std::string bold(const std::string & s) { return "\033[1m" + s + RESET; };
 
 } // namespace Util::Log

--- a/src/util/log.hpp
+++ b/src/util/log.hpp
@@ -24,5 +24,6 @@ std::string bold(const std::string &);
 std::string blue(const std::string &);
 std::string green(const std::string &);
 std::string red(const std::string &);
+std::string yellow(const std::string &);
 
 } // namespace Util::Log

--- a/tests/dsl/06 messages/meson.build
+++ b/tests/dsl/06 messages/meson.build
@@ -1,0 +1,11 @@
+project('messages')
+
+message('foo')
+message('bar')
+
+warning('oink')
+
+message('after', 'warning')
+
+error('oh no!')
+warning('Okay!')


### PR DESCRIPTION
With the caveat that meson++ still flattens all inputs to the message family, unlike Meson.

Fixes #66 