### PR TITLE
Implement unary ops

### DIFF
--- a/src/frontend/parser.yy
+++ b/src/frontend/parser.yy
@@ -81,6 +81,7 @@
 %nterm <std::vector<AST::ElifBlock>>                elif_clause in_elif_clause
 %nterm <AST::IfBlock>                               if_clause
 
+%right                  NOT
 %left                   "-" "+"
 %left                   "*" "/" "%"
 %left                   "."
@@ -90,7 +91,6 @@
 %nonassoc               "?" ":"
 %nonassoc               IF ELIF ELSE ENDIF
 %right                  UMINUS      // Negation
-%right                  NOT
 
 %%
 

--- a/src/mir/ast_to_mir_test.cpp
+++ b/src/mir/ast_to_mir_test.cpp
@@ -615,3 +615,23 @@ TEST(ast_to_ir, assign_from_id) {
     ASSERT_EQ(ir->var.name, "a");
     ASSERT_EQ(ir->var.version, 0);
 }
+
+TEST(ast_to_ir, not_simple) {
+    auto irlist = lower("not true");
+    ASSERT_EQ(irlist.instructions.size(), 1);
+    const auto & obj = irlist.instructions.front();
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<MIR::FunctionCall>>(obj));
+    const auto & ir = std::get<std::shared_ptr<MIR::FunctionCall>>(obj);
+    ASSERT_EQ(ir->name, "unary_not");
+    ASSERT_EQ(std::get<std::shared_ptr<MIR::Boolean>>(ir->pos_args[0])->value, true);
+}
+
+TEST(ast_to_ir, neg_simple) {
+    auto irlist = lower("-5");
+    ASSERT_EQ(irlist.instructions.size(), 1);
+    const auto & obj = irlist.instructions.front();
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<MIR::FunctionCall>>(obj));
+    const auto & ir = std::get<std::shared_ptr<MIR::FunctionCall>>(obj);
+    ASSERT_EQ(ir->name, "unary_neg");
+    ASSERT_EQ(std::get<std::shared_ptr<MIR::Number>>(ir->pos_args[0])->value, 5);
+}

--- a/src/mir/ast_to_mir_test.cpp
+++ b/src/mir/ast_to_mir_test.cpp
@@ -626,6 +626,15 @@ TEST(ast_to_ir, not_simple) {
     ASSERT_EQ(std::get<std::shared_ptr<MIR::Boolean>>(ir->pos_args[0])->value, true);
 }
 
+TEST(ast_to_ir, not_method) {
+    auto irlist = lower("not x.method()");
+    ASSERT_EQ(irlist.instructions.size(), 1);
+    const auto & obj = irlist.instructions.front();
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<MIR::FunctionCall>>(obj));
+    const auto & ir = std::get<std::shared_ptr<MIR::FunctionCall>>(obj);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<MIR::FunctionCall>>(ir->pos_args[0]));
+}
+
 TEST(ast_to_ir, neg_simple) {
     auto irlist = lower("-5");
     ASSERT_EQ(irlist.instructions.size(), 1);

--- a/src/mir/passes/tests/free_functions_test.cpp
+++ b/src/mir/passes/tests/free_functions_test.cpp
@@ -240,3 +240,31 @@ TEST(file, not_equal) {
     MIR::File i{"foO.c", "sub", true, "/home/user/src", "/home/user/src/build"};
     ASSERT_NE(f, i);
 }
+
+TEST(not, simple) {
+    auto irlist = lower("not false");
+    const MIR::State::Persistant pstate{src_root, build_root};
+    bool progress = MIR::Passes::lower_free_functions(&irlist, pstate);
+    ASSERT_TRUE(progress);
+    ASSERT_EQ(irlist.instructions.size(), 1);
+
+    const auto & r = irlist.instructions.back();
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<MIR::Boolean>>(r));
+
+    const auto & m = std::get<std::shared_ptr<MIR::Boolean>>(r);
+    ASSERT_EQ(m->value, true);
+}
+
+TEST(neg, simple) {
+    auto irlist = lower("-5");
+    const MIR::State::Persistant pstate{src_root, build_root};
+    bool progress = MIR::Passes::lower_free_functions(&irlist, pstate);
+    ASSERT_TRUE(progress);
+    ASSERT_EQ(irlist.instructions.size(), 1);
+
+    const auto & r = irlist.instructions.back();
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<MIR::Number>>(r));
+
+    const auto & m = std::get<std::shared_ptr<MIR::Number>>(r);
+    ASSERT_EQ(m->value, -5);
+}

--- a/tests/dsl/07 find_program/meson.build
+++ b/tests/dsl/07 find_program/meson.build
@@ -12,5 +12,4 @@ x = find_program('sh')
 assert(x.found(), 'sh was not found?')
 
 y = find_program('not found', required : false)
-# disabled because it casues the test runner to fail
-#assert(y.found(), '"not found" was not found?')
+assert(not y.found(), '"not found" was found?')


### PR DESCRIPTION
This allows the `not` and `-` (unary, not subtractive) operator to be parsed into AST, and then converted into MIR, and lowered away. 