### PR TITLE
Refactor function lowering

### DIFF
--- a/src/mir/passes/private.hpp
+++ b/src/mir/passes/private.hpp
@@ -72,8 +72,8 @@ template <typename T> std::optional<T> extract_positional_argument(const Object 
 }
 
 template <typename T>
-std::vector<T> extract_variadic_arguments(std::vector<Object>::iterator start,
-                                          std::vector<Object>::iterator end) {
+std::vector<T> extract_variadic_arguments(std::vector<Object>::const_iterator start,
+                                          std::vector<Object>::const_iterator end) {
     std::vector<T> nobjs{};
     for (; start != end; start++) {
         // TODO: this is going to ignore invalid arghuments

--- a/src/mir/passes/program_objects.cpp
+++ b/src/mir/passes/program_objects.cpp
@@ -9,42 +9,47 @@ namespace MIR::Passes {
 
 namespace {
 
-std::optional<Object> lower_found_method(const Object & obj) {
-    if (!std::holds_alternative<std::shared_ptr<FunctionCall>>(obj)) {
-        return std::nullopt;
-    }
-    const auto & f = std::get<std::shared_ptr<FunctionCall>>(obj);
-
-    if (!(f->holder.has_value() &&
-          std::holds_alternative<std::shared_ptr<Program>>(f->holder.value())) ||
-        f->name != "found") {
-        return std::nullopt;
-    }
-
-    if (!f->pos_args.empty()) {
+std::optional<Object> lower_found_method(const FunctionCall & f) {
+    if (!f.pos_args.empty()) {
         throw Util::Exceptions::InvalidArguments(
             "Program.found() does not take any positional arguments");
     }
-    if (!f->kw_args.empty()) {
+    if (!f.kw_args.empty()) {
         throw Util::Exceptions::InvalidArguments(
             "Program.found() does not take any keyword arguments");
     }
 
-    return std::make_shared<Boolean>(
-        std::get<std::shared_ptr<Program>>(f->holder.value())->found());
+    return std::make_shared<Boolean>(std::get<std::shared_ptr<Program>>(f.holder.value())->found());
 }
 
+std::optional<Object> lower_program_methods_impl(const Object & obj,
+                                                 const State::Persistant & pstate) {
+    if (!std::holds_alternative<std::shared_ptr<FunctionCall>>(obj)) {
+        return std::nullopt;
+    }
+    const auto & f = *std::get<std::shared_ptr<FunctionCall>>(obj);
+
+    if (!(f.holder.has_value() &&
+          std::holds_alternative<std::shared_ptr<Program>>(f.holder.value()))) {
+        return std::nullopt;
+    }
+
+    if (!all_args_reduced(f.pos_args, f.kw_args)) {
+        return std::nullopt;
+    }
+
+    if (f.name == "found") {
+        return lower_found_method(f);
+    }
+
+    // XXX: Shouldn't really be able to get here...
+    return std::nullopt;
+}
 } // namespace
 
 bool lower_program_objects(BasicBlock & block, State::Persistant & pstate) {
-    bool progress = false;
-    // clang-format off
-    return false
-        || function_walker(&block, lower_found_method)
-        ;
-    // clang-format on
-
-    return progress;
+    return function_walker(
+        &block, [&](const Object & obj) { return lower_program_methods_impl(obj, pstate); });
 }
 
 } // namespace MIR::Passes


### PR DESCRIPTION
Currently, on each object, for each function lowering method, we check if the thing is a function, then we check the holder, and the name of the function, returning if the current lowering function doesn't act on it. This is pretty inefficient, just in our very limited tests it adds about .01 seconds to the run time, and there area a *lot* of unimplemented functions and methods. The new code is not perfect, but it uses a dispatch function to avoid some of the overhead by only doing the variant extraction once, as well as the name and holder check once.

Fixes #87