### PR TITLE
Initial support for declare_dependency

### DIFF
--- a/src/mir/lower.cpp
+++ b/src/mir/lower.cpp
@@ -33,6 +33,7 @@ void lower_impl(BasicBlock & block, State::Persistant & pstate) {
                 [&](BasicBlock * b) { return Passes::constant_propogation(b, pt); },
                 [&](BasicBlock * b) { return Passes::lower_program_objects(*b, pstate); },
                 [&](BasicBlock * b) { return Passes::lower_string_objects(*b, pstate); },
+                [&](BasicBlock * b) { return Passes::lower_dependency_objects(*b, pstate); },
             });
     }
 }

--- a/src/mir/meson.build
+++ b/src/mir/meson.build
@@ -13,6 +13,7 @@ libmir = static_library(
     'passes/constant_folding.cpp',
     'passes/constant_propogation.cpp',
     'passes/dead_code.cpp',
+    'passes/dependency_objects.cpp',
     'passes/flatten.cpp',
     'passes/free_functions.cpp',
     'passes/insert_phis.cpp',

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -194,4 +194,8 @@ CustomTarget::CustomTarget(const std::string & n, const std::vector<Source> & i,
                            const fs::path & s, const Variable & v)
     : name{n}, inputs{i}, outputs{o}, command{c}, subdir{s}, var{v} {};
 
+Dependency::Dependency(const std::string & n, const bool & f, const std::string & ver,
+                       const std::vector<Arguments::Argument> & a, const Variable & v)
+    : name{n}, found{f}, version{ver}, arguments{a}, var{v} {};
+
 } // namespace MIR

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -224,6 +224,38 @@ class IncludeDirectories {
     Variable var;
 };
 
+enum class DependencyType {
+    INTERNAL,
+};
+
+/**
+ * A dependency object
+ *
+ * Holds files, arguments, etc, to apply to build targets
+ */
+class Dependency {
+  public:
+    Dependency(const std::string & name, const bool & found, const std::string & version,
+               const std::vector<Arguments::Argument> & args, const Variable & var);
+
+    /// Name of the dependency
+    const std::string name;
+
+    /// whether or not the dependency is found
+    const bool found;
+
+    /// The version of the dependency
+    const std::string version;
+
+    /// Per-language compiler args
+    const std::vector<Arguments::Argument> arguments;
+
+    /// The kind of dependency this is
+    const DependencyType type = DependencyType::INTERNAL;
+
+    Variable var;
+};
+
 enum class MessageLevel {
     DEBUG,
     MESSAGE,
@@ -286,7 +318,8 @@ using Object =
                  std::shared_ptr<Dict>, std::shared_ptr<Compiler>, std::shared_ptr<File>,
                  std::shared_ptr<Executable>, std::shared_ptr<StaticLibrary>, std::unique_ptr<Phi>,
                  std::shared_ptr<IncludeDirectories>, std::unique_ptr<Message>,
-                 std::shared_ptr<Program>, std::unique_ptr<Empty>, std::shared_ptr<CustomTarget>>;
+                 std::shared_ptr<Program>, std::unique_ptr<Empty>, std::shared_ptr<CustomTarget>,
+                 std::shared_ptr<Dependency>>;
 
 /**
  * Holds a toolchain

--- a/src/mir/passes.hpp
+++ b/src/mir/passes.hpp
@@ -124,6 +124,9 @@ bool lower_program_objects(BasicBlock &, State::Persistant & pstate);
 /// Lower string object methods
 bool lower_string_objects(BasicBlock & block, State::Persistant & pstate);
 
+/// Lower dependency object methods
+bool lower_dependency_objects(BasicBlock & block, State::Persistant & pstate);
+
 /// Delete any code that has become unreachable
 bool delete_unreachable(BasicBlock & block);
 

--- a/src/mir/passes/argument_extractors.hpp
+++ b/src/mir/passes/argument_extractors.hpp
@@ -1,0 +1,136 @@
+// SPDX-license-identifier: Apache-2.0
+// Copyright © 2021-2022 Dylan Baker
+
+/**
+ * Helpers to extract arguments and keyword arguments
+ */
+
+#pragma once
+
+#include <optional>
+#include <variant>
+
+#include "mir.hpp"
+
+namespace MIR::Passes {
+
+template <typename T> std::optional<T> extract_positional_argument(const Object & arg) {
+    if (std::holds_alternative<T>(arg)) {
+        return std::get<T>(arg);
+    }
+    // TODO: this ignores invalid arguments
+    return std::nullopt;
+}
+
+template <typename R> R _extract_positional_argument_v(const Object & arg) {
+    return std::monostate{};
+}
+
+template <typename R, typename T, typename... Args>
+R _extract_positional_argument_v(const Object & arg) {
+    if (std::holds_alternative<T>(arg)) {
+        return std::get<T>(arg);
+    }
+    return _extract_positional_argument_v<R, Args...>(arg);
+}
+
+template <typename T, typename... Args>
+std::variant<std::monostate, T, Args...> extract_positional_argument_v(const Object & arg) {
+    if (std::holds_alternative<T>(arg)) {
+        return std::get<T>(arg);
+    }
+    // TODO: this ignores invalid arguments
+    return _extract_positional_argument_v<std::variant<std::monostate, T, Args...>, Args...>(arg);
+}
+
+template <typename T>
+std::vector<T> extract_variadic_arguments(std::vector<Object>::const_iterator start,
+                                          std::vector<Object>::const_iterator end) {
+    std::vector<T> nobjs{};
+    for (; start != end; start++) {
+        if (std::holds_alternative<std::shared_ptr<Array>>(*start)) {
+            const auto & arr = *std::get<std::shared_ptr<Array>>(*start);
+            const auto & nvals = extract_variadic_arguments<T>(arr.value.begin(), arr.value.end());
+            nobjs.insert(nobjs.end(), nvals.begin(), nvals.end());
+        } else {
+            // TODO: this is going to ignore invalid arghuments
+            std::optional<T> arg = extract_positional_argument<T>(*start);
+            if (arg) {
+                nobjs.emplace_back(arg.value());
+            }
+        }
+    }
+    return nobjs;
+}
+
+template <typename T>
+std::optional<T> extract_keyword_argument(const std::unordered_map<std::string, Object> & kwargs,
+                                          const std::string & name) {
+    const auto & found = kwargs.find(name);
+    if (found == kwargs.end()) {
+        return std::nullopt;
+    } else if (!std::holds_alternative<T>(found->second)) {
+        // XXX: this is just going to ignore invalid arguments…
+        return std::nullopt;
+    }
+    return std::get<T>(found->second);
+}
+
+template <typename T, typename... Args>
+std::variant<std::monostate, T, Args...>
+extract_keyword_argument_v(const std::unordered_map<std::string, Object> & kwargs,
+                           const std::string & name) {
+    // FIXME: this has the same problem as the other version, which is that you
+    // can't distinguish between "not present" and "not a valid type"
+    const auto & found = kwargs.find(name);
+    if (found == kwargs.end()) {
+        return std::monostate{};
+    }
+    return extract_positional_argument_v<T, Args...>(found->second);
+}
+
+template <typename T>
+std::vector<T> extract_keyword_argument_a(const std::unordered_map<std::string, Object> & kwargs,
+                                          const std::string & name, const bool & as_list = false) {
+    auto found = kwargs.find(name);
+    if (found == kwargs.end()) {
+        return {};
+    } else if (std::holds_alternative<T>(found->second)) {
+        return {std::vector<T>{std::get<T>(found->second)}};
+    } else if (std::holds_alternative<std::shared_ptr<Array>>(found->second)) {
+        std::vector<T> ret{};
+        for (const auto & a : std::get<std::shared_ptr<Array>>(found->second)->value) {
+            auto arg = extract_positional_argument<T>(a);
+            // XXX: also ignores invalid arguments
+            if (arg) {
+                ret.emplace_back(arg.value());
+            }
+        }
+        return ret;
+    }
+    // XXX: This ignores invalid arguments
+    return {};
+}
+
+template <typename... Args>
+std::vector<std::variant<std::monostate, Args...>>
+extract_keyword_argument_av(const std::unordered_map<std::string, Object> & kwargs,
+                            const std::string & name) {
+    // FIXME: this has the same problem as the other version, which is that you
+    // can't distinguish between "not present" and "not a valid type"
+    const auto & found = kwargs.find(name);
+    if (found == kwargs.end()) {
+        return {};
+    } else if (std::holds_alternative<std::shared_ptr<Array>>(found->second)) {
+        std::vector<std::variant<std::monostate, Args...>> ret{};
+        for (const auto & a : std::get<std::shared_ptr<Array>>(found->second)->value) {
+            // XXX: also ignores invalid arguments
+            ret.emplace_back(extract_positional_argument_v<Args...>(a));
+        }
+        return ret;
+    } else {
+        return {extract_positional_argument_v<Args...>(found->second)};
+    }
+}
+
+} // namespace MIR::Passes

--- a/src/mir/passes/constant_propogation.cpp
+++ b/src/mir/passes/constant_propogation.cpp
@@ -52,6 +52,8 @@ std::optional<Object> get_value(const Identifier & id, const PropTable & table) 
             return std::get<std::shared_ptr<IncludeDirectories>>(v);
         } else if (std::holds_alternative<std::shared_ptr<CustomTarget>>(v)) {
             return std::get<std::shared_ptr<CustomTarget>>(v);
+        } else if (std::holds_alternative<std::shared_ptr<Dependency>>(v)) {
+            return std::get<std::shared_ptr<Dependency>>(v);
 #ifndef NDEBUG
         } else if (!(std::holds_alternative<std::unique_ptr<Phi>>(v) &&
                      std::holds_alternative<std::unique_ptr<Identifier>>(v) &&

--- a/src/mir/passes/dependency_objects.cpp
+++ b/src/mir/passes/dependency_objects.cpp
@@ -1,0 +1,88 @@
+// SPDX-license-identifier: Apache-2.0
+// Copyright © 2022 Dylan Baker
+
+#include "exceptions.hpp"
+#include "passes.hpp"
+#include "private.hpp"
+
+namespace MIR::Passes {
+
+namespace {
+
+std::optional<Object> lower_found_method(const FunctionCall & f) {
+    if (!f.pos_args.empty()) {
+        throw Util::Exceptions::InvalidArguments(
+            "Dependency.found() does not take any positional arguments");
+    }
+    if (!f.kw_args.empty()) {
+        throw Util::Exceptions::InvalidArguments(
+            "Dependency.found() does not take any keyword arguments");
+    }
+
+    return std::make_shared<Boolean>(
+        std::get<std::shared_ptr<Dependency>>(f.holder.value())->found);
+}
+
+std::optional<Object> lower_version_method(const FunctionCall & f) {
+    if (!f.pos_args.empty()) {
+        throw Util::Exceptions::InvalidArguments(
+            "Dependency.version() does not take any positional arguments");
+    }
+    if (!f.kw_args.empty()) {
+        throw Util::Exceptions::InvalidArguments(
+            "Dependency.version() does not take any keyword arguments");
+    }
+
+    return std::make_shared<String>(
+        std::get<std::shared_ptr<Dependency>>(f.holder.value())->version);
+}
+
+std::optional<Object> lower_name_method(const FunctionCall & f) {
+    if (!f.pos_args.empty()) {
+        throw Util::Exceptions::InvalidArguments(
+            "Dependency.name() does not take any positional arguments");
+    }
+    if (!f.kw_args.empty()) {
+        throw Util::Exceptions::InvalidArguments(
+            "Dependency.name() does not take any keyword arguments");
+    }
+
+    return std::make_shared<String>(std::get<std::shared_ptr<Dependency>>(f.holder.value())->name);
+}
+
+std::optional<Object> lower_dependency_methods_impl(const Object & obj,
+                                                    const State::Persistant & pstate) {
+    if (!std::holds_alternative<std::shared_ptr<FunctionCall>>(obj)) {
+        return std::nullopt;
+    }
+    const auto & f = *std::get<std::shared_ptr<FunctionCall>>(obj);
+
+    if (!(f.holder.has_value() &&
+          std::holds_alternative<std::shared_ptr<Dependency>>(f.holder.value()))) {
+        return std::nullopt;
+    }
+
+    if (!all_args_reduced(f.pos_args, f.kw_args)) {
+        return std::nullopt;
+    }
+
+    if (f.name == "found") {
+        return lower_found_method(f);
+    } else if (f.name == "version") {
+        return lower_version_method(f);
+    } else if (f.name == "name") {
+        return lower_name_method(f);
+    }
+
+    // XXX: Shouldn't really be able to get here...
+    return std::nullopt;
+}
+
+} // namespace
+
+bool lower_dependency_objects(BasicBlock & block, State::Persistant & pstate) {
+    return function_walker(
+        &block, [&](const Object & obj) { return lower_dependency_methods_impl(obj, pstate); });
+}
+
+} // namespace MIR::Passes

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -1,5 +1,5 @@
 // SPDX-license-identifier: Apache-2.0
-// Copyright © 2021 Dylan Baker
+// Copyright © 2021-2022 Dylan Baker
 
 #include <iostream>
 #include <vector>
@@ -476,6 +476,7 @@ bool holds_reduced(const Object & obj) {
             std::holds_alternative<std::shared_ptr<IncludeDirectories>>(obj) ||
             std::holds_alternative<std::shared_ptr<Program>>(obj) ||
             std::holds_alternative<std::shared_ptr<CustomTarget>>(obj) ||
+            std::holds_alternative<std::shared_ptr<Dependency>>(obj) ||
             std::holds_alternative<std::unique_ptr<Message>>(obj) || holds_reduced_array(obj) ||
             holds_reduced_dict(obj));
 }

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <vector>
 
+#include "argument_extractors.hpp"
 #include "exceptions.hpp"
 #include "log.hpp"
 #include "passes.hpp"
@@ -69,7 +70,7 @@ target_arguments(const FunctionCall & f, const State::Persistant & pstate) {
     }
 
     const auto & comp = comp_at->second.build()->compiler;
-    auto raw_args = extract_array_keyword_argument<std::shared_ptr<String>>(f.kw_args, "cpp_args");
+    auto raw_args = extract_keyword_argument_a<std::shared_ptr<String>>(f.kw_args, "cpp_args");
     for (const auto & ra : raw_args) {
         args[Toolchain::Language::CPP].emplace_back(comp->generalize_argument(ra->value));
     }
@@ -80,8 +81,7 @@ target_arguments(const FunctionCall & f, const State::Persistant & pstate) {
 inline std::vector<StaticLinkage>
 target_kwargs(const std::unordered_map<std::string, Object> & kwargs) {
     std::vector<StaticLinkage> s_link{};
-    auto raw_args =
-        extract_array_keyword_argument<std::shared_ptr<StaticLibrary>>(kwargs, "link_with");
+    auto raw_args = extract_keyword_argument_a<std::shared_ptr<StaticLibrary>>(kwargs, "link_with");
     for (const auto & s : raw_args) {
         s_link.emplace_back(StaticLinkage{StaticLinkMode::NORMAL, s.get()});
     }
@@ -120,7 +120,7 @@ std::optional<std::shared_ptr<T>> lower_build_target(const FunctionCall & f,
     }
     auto args = target_arguments(f, pstate);
     auto slink = target_kwargs(f.kw_args);
-    auto raw_inc = extract_array_keyword_argument<std::shared_ptr<IncludeDirectories>>(
+    auto raw_inc = extract_keyword_argument_a<std::shared_ptr<IncludeDirectories>>(
         f.kw_args, "include_directories", true);
     for (const auto & i : raw_inc) {
         for (const auto & d : i->directories) {
@@ -423,7 +423,7 @@ std::optional<Object> lower_custom_target(const FunctionCall & func,
 
     std::vector<File> outputs{};
     for (const auto & a :
-         extract_array_keyword_argument<std::shared_ptr<String>>(func.kw_args, "output")) {
+         extract_keyword_argument_a<std::shared_ptr<String>>(func.kw_args, "output")) {
         outputs.emplace_back(
             File{a->value, func.source_dir, true, pstate.source_root, pstate.build_root});
     }

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -120,6 +120,14 @@ std::optional<std::shared_ptr<T>> lower_build_target(const FunctionCall & f,
         }
     }
 
+    const auto & deps =
+        extract_keyword_argument_a<std::shared_ptr<Dependency>>(f.kw_args, "dependencies");
+    for (const auto & d : deps) {
+        for (const auto & a : d->arguments) {
+            args[Toolchain::Language::CPP].emplace_back(a);
+        }
+    }
+
     // TODO: machine parameter needs to be set from the native kwarg
     return std::make_shared<T>(name.value()->value, srcs, Machines::Machine::BUILD, f.source_dir,
                                args, slink, f.var);

--- a/src/mir/passes/private.hpp
+++ b/src/mir/passes/private.hpp
@@ -9,7 +9,6 @@
 
 #include "mir.hpp"
 #include <functional>
-#include <optional>
 
 namespace MIR::Passes {
 
@@ -62,70 +61,5 @@ bool block_walker(BasicBlock *, const std::vector<BlockWalkerCb> &);
 /// Check if all of the arguments have been reduced from ids
 bool all_args_reduced(const std::vector<Object> & pos_args,
                       const std::unordered_map<std::string, Object> & kw_args);
-
-template <typename T> std::optional<T> extract_positional_argument(const Object & arg) {
-    if (std::holds_alternative<T>(arg)) {
-        return std::get<T>(arg);
-    }
-    // TODO: this ignores invalid arguments
-    return std::nullopt;
-}
-
-template <typename T>
-std::vector<T> extract_variadic_arguments(std::vector<Object>::const_iterator start,
-                                          std::vector<Object>::const_iterator end) {
-    std::vector<T> nobjs{};
-    for (; start != end; start++) {
-        if (std::holds_alternative<std::shared_ptr<Array>>(*start)) {
-            const auto & arr = *std::get<std::shared_ptr<Array>>(*start);
-            const auto & nvals = extract_variadic_arguments<T>(arr.value.begin(), arr.value.end());
-            nobjs.insert(nobjs.end(), nvals.begin(), nvals.end());
-        } else {
-            // TODO: this is going to ignore invalid arghuments
-            std::optional<T> arg = extract_positional_argument<T>(*start);
-            if (arg) {
-                nobjs.emplace_back(arg.value());
-            }
-        }
-    }
-    return nobjs;
-}
-
-template <typename T>
-std::optional<T> extract_keyword_argument(const std::unordered_map<std::string, Object> & kwargs,
-                                          const std::string & name) {
-    const auto & found = kwargs.find(name);
-    if (found == kwargs.end()) {
-        return std::nullopt;
-    } else if (!std::holds_alternative<T>(found->second)) {
-        // XXX: this is just going to ignore invalid arguments…
-        return std::nullopt;
-    }
-    return std::get<T>(found->second);
-}
-
-template <typename T>
-std::vector<T>
-extract_array_keyword_argument(const std::unordered_map<std::string, Object> & kwargs,
-                               const std::string & name, const bool & as_list = false) {
-    auto found = kwargs.find(name);
-    if (found == kwargs.end()) {
-        return {};
-    } else if (std::holds_alternative<T>(found->second)) {
-        return {std::vector<T>{std::get<T>(found->second)}};
-    } else if (std::holds_alternative<std::shared_ptr<Array>>(found->second)) {
-        std::vector<T> ret{};
-        for (const auto & a : std::get<std::shared_ptr<Array>>(found->second)->value) {
-            auto arg = extract_positional_argument<T>(a);
-            // XXX: also ignores invalid arguments
-            if (arg) {
-                ret.emplace_back(arg.value());
-            }
-        }
-        return ret;
-    }
-    // XXX: This ignores invalid arguments
-    return {};
-}
 
 } // namespace MIR::Passes

--- a/src/mir/passes/string_objects.cpp
+++ b/src/mir/passes/string_objects.cpp
@@ -5,6 +5,7 @@
 #include "meson/version.hpp"
 #include "passes.hpp"
 #include "private.hpp"
+#include "argument_extractors.hpp"
 
 namespace MIR::Passes {
 

--- a/src/mir/passes/threaded.cpp
+++ b/src/mir/passes/threaded.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <mutex>
 
+#include "argument_extractors.hpp"
 #include "exceptions.hpp"
 #include "log.hpp"
 #include "passes.hpp"

--- a/tests/dsl/10 dependency methods/meson.build
+++ b/tests/dsl/10 dependency methods/meson.build
@@ -1,0 +1,6 @@
+project('dependency methods')
+
+d = declare_dependency(version : '1.2.3')
+assert(d.found())
+assert(d.version() == '1.2.3')
+assert(d.name() == 'internal')


### PR DESCRIPTION
This only provides very basic declare dependency support, but it's a start. With this we can:
- call `declare_dependency()` and get a valid object
- call the `.found()` method
- call the `.name()` method
- call the `.version()` method

Fixes #16 