### PR TITLE
meson: use pkgconf++ 0.2.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,8 +45,8 @@ dep_rpm_version_cpp = dependency(
   default_options : ['default_library=static'],
 )
 dep_pkgconf = dependency(
-  'libpkgconf++',
-  version : '>= 0.1.0',
+  'pkgconf++',
+  version : '>= 0.2.0',
   required : get_option('pkgconf'),
   fallback : ['libpkgconfpp', 'dep_libpkgconf++'],
   default_options : ['default_library=static'],

--- a/subprojects/libpkgconfpp.wrap
+++ b/subprojects/libpkgconfpp.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/dcbaker/libpkgconfpp
-revision = v0.1.0
+revision = v0.2.0
 
 


### PR DESCRIPTION
Which has a fixed name so that pkg-config and fallback work correctly