### PR TITLE
mir/passes/threaded: fix lock guards

### DIFF
--- a/src/mir/passes/threaded.cpp
+++ b/src/mir/passes/threaded.cpp
@@ -82,17 +82,17 @@ class FindList {
     FindList & operator=(const FindList &) = delete;
 
     void emplace(const Type t, const std::vector<std::string> && v) {
-        std::lock_guard{lock};
+        std::lock_guard l{lock};
         jobs.emplace_back(t, std::move(v));
     }
 
     bool empty() {
-        std::lock_guard{lock};
+        std::lock_guard l{lock};
         return jobs.empty();
     }
 
     std::tuple<Type, std::vector<std::string>> get() {
-        std::lock_guard{lock};
+        std::lock_guard l{lock};
         auto out = std::move(jobs.back());
         jobs.pop_back();
         return out;


### PR DESCRIPTION
```
The lock guard objects were unnamed, therefore
they were immediately destroyed, thus they
did not keep the mutex locked during the scope
they were declared in. This was found by clang-tidy.
```

Fixes: 42a15e6eed641662d1ca418690eeeca4fc226a75 ("threaded: encapsulate locking for Job list completely")