### PR TITLE
mir/passes/threaded: find_program: correctly split PATH and ignore zero length components

### DIFF
--- a/src/mir/passes/threaded.cpp
+++ b/src/mir/passes/threaded.cpp
@@ -50,6 +50,9 @@ void find_program(const std::vector<std::string> & names, std::mutex & lock,
 
             p.remove_prefix(dirname.length() + (l != p.npos)); // skip dirname and separator (if there is one)
 
+            if (dirname.empty())
+                continue;
+
             fs::path trial = fs::path{dirname} / name;
             if (fs::exists(trial)) {
                 std::lock_guard l{lock};


### PR DESCRIPTION
See commits messages for more details.