### PR TITLE
CI: update actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
       uses: actions/setup-python@v1
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,9 @@ jobs:
         sudo apt install libfl-dev libgtest-dev
 
     - name: setup python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
 
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libfl-dev libgtest-dev ninja-build ccache clang
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v1
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.0.5
@@ -56,7 +56,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libfl-dev libgtest-dev ninja-build clang-tidy
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v1
       - name: install meson
         run: pip install meson==0.60.3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -36,7 +36,9 @@ jobs:
           sudo apt update
           sudo apt install libfl-dev libgtest-dev ninja-build ccache clang
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.0.5
         with:
@@ -57,7 +59,9 @@ jobs:
           sudo apt update
           sudo apt install libfl-dev libgtest-dev ninja-build clang-tidy
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: install meson
         run: pip install meson==0.60.3
       - name: generate headers


### PR DESCRIPTION
Mostly, we just need to pin python at 3.10, because the version of Meson I want to stick with for the moment is broken on 3.11