### PR TITLE
mir: replace custom_target string command with find_program call

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-faster-string-find,performance-unnecessary-value-param,modernize-raw-string-literal,modernize-pass-by-value,modernize-loop-convert,modernize-use-nullptr,modernize-use-using,readability-redundant-member-init,readability-const-return-type,readability-else-after-return,readability-container-size-empty,readability-redundant-string-init,readability-use-anyofallof,readability-redundant-smartptr-get'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            dylan
 CheckOptions:

--- a/src/mir/lower.cpp
+++ b/src/mir/lower.cpp
@@ -53,6 +53,7 @@ void lower(BasicBlock & block, State::Persistant & pstate) {
                                         return Passes::machine_lower(b, pstate.machines) ||
                                                Passes::insert_compilers(b, pstate.toolchains);
                                     },
+                                    Passes::custom_target_program_replacement,
                                     Passes::GlobalValueNumbering{},
                                 });
 

--- a/src/mir/meson.build
+++ b/src/mir/meson.build
@@ -12,6 +12,7 @@ libmir = static_library(
     'passes/compilers.cpp',
     'passes/constant_folding.cpp',
     'passes/constant_propogation.cpp',
+    'passes/custom_target_program_replacement.cpp',
     'passes/dead_code.cpp',
     'passes/dependency_objects.cpp',
     'passes/flatten.cpp',
@@ -28,16 +29,16 @@ libmir = static_library(
     'passes/walkers.cpp',
     locations_hpp,
   ],
-  include_directories : inc_frontend,
-  dependencies : [idep_util, idep_meson, dependency('threads')],
+  include_directories: inc_frontend,
+  dependencies: [idep_util, idep_meson, dependency('threads')],
 )
 
 inc_mir = include_directories('.')
 
 idep_mir = declare_dependency(
-  link_with : libmir,
-  include_directories : inc_mir,
-  dependencies : [idep_meson],
+  link_with: libmir,
+  include_directories: inc_mir,
+  dependencies: [idep_meson],
 )
 
 test(
@@ -45,9 +46,9 @@ test(
   executable(
     'ast_to_mir_test',
     ['ast_to_mir_test.cpp', locations_hpp],
-    dependencies : [idep_frontend, idep_mir, dep_gtest],
+    dependencies: [idep_frontend, idep_mir, dep_gtest],
   ),
-  protocol : 'gtest',
+  protocol: 'gtest',
 )
 
 test(
@@ -58,9 +59,9 @@ test(
       'mir_tests.cpp',
       locations_hpp,
     ],
-    dependencies : [idep_frontend, idep_mir, dep_gtest],
+    dependencies: [idep_frontend, idep_mir, dep_gtest],
   ),
-  protocol : 'gtest',
+  protocol: 'gtest',
 )
 
 test(
@@ -71,6 +72,7 @@ test(
       'passes/tests/branch_pruning_test.cpp',
       'passes/tests/const_folding_test.cpp',
       'passes/tests/constant_propogation_test.cpp',
+      'passes/tests/custom_target_program_replacement_test.cpp',
       'passes/tests/dead_code_test.cpp',
       'passes/tests/fixup_phis_test.cpp',
       'passes/tests/flatten_test.cpp',
@@ -85,7 +87,7 @@ test(
       'passes/tests/walker_tests.cpp',
       locations_hpp,
     ],
-    dependencies : [idep_frontend, idep_mir, idep_util, dep_gtest],
+    dependencies: [idep_frontend, idep_mir, idep_util, dep_gtest],
   ),
-  protocol : 'gtest',
+  protocol: 'gtest',
 )

--- a/src/mir/passes.hpp
+++ b/src/mir/passes.hpp
@@ -51,6 +51,12 @@ bool insert_compilers(BasicBlock &,
                           MIR::Machines::PerMachine<std::shared_ptr<MIR::Toolchain::Toolchain>>> &);
 
 /**
+ * Find string arguments to custom_target's program space (intput[0]), and
+ * replace it with a call to `find_program()`
+ */
+bool custom_target_program_replacement(BasicBlock &);
+
+/**
  * Lowering for free functions
  *
  * This lowers free standing functions (those not part of an object/namespace).

--- a/src/mir/passes/custom_target_program_replacement.cpp
+++ b/src/mir/passes/custom_target_program_replacement.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2024 Intel Corporation
+
+#include "argument_extractors.hpp"
+#include "passes.hpp"
+#include "private.hpp"
+
+namespace MIR::Passes {
+
+namespace {
+
+bool program_replacement_impl(Instruction & obj) {
+    if (!std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr)) {
+        return false;
+    }
+
+    auto & fc = std::get<MIR::FunctionCall>(*obj.obj_ptr);
+    if (fc.name != "custom_target") {
+        return false;
+    }
+
+    const auto & cmd_obj_v =
+        extract_keyword_argument_v<MIR::Array, MIR::String>(fc.kw_args, "command");
+    // TODO: should this be an error?
+    if (std::holds_alternative<std::monostate>(cmd_obj_v)) {
+        return false;
+    }
+
+    if (std::holds_alternative<MIR::Array>(cmd_obj_v)) {
+        auto commands = std::get<MIR::Array>(cmd_obj_v).value;
+        // TODO: should this be an error?
+        if (commands.empty()) {
+            return false;
+        }
+        const Instruction & cmd = commands.at(0);
+        if (std::holds_alternative<MIR::String>(*cmd.obj_ptr)) {
+            auto s = std::get<MIR::String>(*cmd.obj_ptr);
+            MIR::FunctionCall fp{"find_program", {std::move(s)}, fc.source_dir};
+            commands[0] = std::move(fp);
+            fc.kw_args["command"] = Array{std::move(commands)};
+        }
+    } else if (std::holds_alternative<MIR::String>(cmd_obj_v)) {
+        auto s = std::get<MIR::String>(cmd_obj_v);
+        MIR::FunctionCall fp{"find_program", {std::move(s)}, fc.source_dir};
+        fc.kw_args["command"] = Array{{std::move(fp)}};
+    } else {
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+bool custom_target_program_replacement(BasicBlock & block) {
+    return instruction_walker(block, {program_replacement_impl});
+}
+
+} // namespace MIR::Passes

--- a/src/mir/passes/tests/custom_target_program_replacement_test.cpp
+++ b/src/mir/passes/tests/custom_target_program_replacement_test.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2024 Intel Corporation
+
+#include "passes.hpp"
+#include "passes/argument_extractors.hpp"
+#include "passes/private.hpp"
+#include "test_utils.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(custom_target_program_replacement, string) {
+    auto irlist = lower(R"EOF(
+        x = custom_target('name', command : 'foo.py')
+        )EOF");
+
+    MIR::Passes::block_walker(irlist, {MIR::Passes::custom_target_program_replacement});
+
+    ASSERT_EQ(irlist.instructions.size(), 1);
+
+    const auto & fc_obj = irlist.instructions.front();
+    const auto & fc = std::get<MIR::FunctionCall>(*fc_obj.obj_ptr);
+
+    const auto & commands_o =
+        MIR::Passes::extract_keyword_argument<MIR::Array>(fc.kw_args, "command");
+    ASSERT_TRUE(commands_o.has_value());
+
+    const auto & commands = commands_o.value();
+    ASSERT_EQ(commands.value.size(), 1);
+
+    const auto & cmd0 = std::get<MIR::FunctionCall>(*commands.value.at(0).obj_ptr);
+    EXPECT_EQ(cmd0.name, "find_program");
+
+    ASSERT_EQ(cmd0.pos_args.size(), 1);
+    const auto & arg_o = MIR::Passes::extract_positional_argument<MIR::String>(cmd0.pos_args.at(0));
+    ASSERT_TRUE(arg_o.has_value());
+    ASSERT_EQ(arg_o.value().value, "foo.py");
+}
+
+TEST(custom_target_program_replacement, array) {
+    auto irlist = lower(R"EOF(
+        x = custom_target('name', command : ['foo.py', '@INPUT@', '@OUTPUT@'])
+        )EOF");
+
+    MIR::Passes::block_walker(irlist, {MIR::Passes::custom_target_program_replacement});
+
+    ASSERT_EQ(irlist.instructions.size(), 1);
+
+    const auto & fc_obj = irlist.instructions.front();
+    const auto & fc = std::get<MIR::FunctionCall>(*fc_obj.obj_ptr);
+
+    const auto & commands_o =
+        MIR::Passes::extract_keyword_argument<MIR::Array>(fc.kw_args, "command");
+    ASSERT_TRUE(commands_o.has_value());
+
+    const auto & commands = commands_o.value();
+    ASSERT_EQ(commands.value.size(), 3);
+
+    const auto & cmd0 = std::get<MIR::FunctionCall>(*commands.value.at(0).obj_ptr);
+    EXPECT_EQ(cmd0.name, "find_program");
+
+    ASSERT_EQ(cmd0.pos_args.size(), 1);
+    const auto & arg_o = MIR::Passes::extract_positional_argument<MIR::String>(cmd0.pos_args.at(0));
+    ASSERT_TRUE(arg_o.has_value());
+    ASSERT_EQ(arg_o.value().value, "foo.py");
+}

--- a/src/mir/passes/tests/lower_test.cpp
+++ b/src/mir/passes/tests/lower_test.cpp
@@ -20,7 +20,7 @@ TEST(lower, after_files) {
         custom_target(
             'gen',
             output : 'gen.c',
-            command : ['prog', files('foo'), '@OUTPUT@']
+            command : ['cp', files('foo'), '@OUTPUT@']
         )
         )EOF");
     MIR::State::Persistant pstate{src_root, build_root};


### PR DESCRIPTION
This is a pass that can be run once, in the early phase, to replace cases where the first argument to `custom_target` is a string, not a `file()`, `find_program()`, or `executable()`, and transform it into a `find_program()` call.

Fixes: #86