### PR TITLE
Clean up argument extractors

### DIFF
--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -368,8 +368,7 @@ std::string Dependency::print() const {
            "; type = " + to_string(type) + " }";
 }
 
-Test::Test(std::string n, Callable exe,
-           std::vector<std::variant<std::monostate, String, File>> args, bool xfail)
+Test::Test(std::string n, Callable exe, std::vector<std::variant<String, File>> args, bool xfail)
     : name{std::move(n)}, executable{std::move(exe)}, arguments{std::move(args)},
       should_fail{xfail} {};
 

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -370,12 +370,11 @@ class Program {
 
 class Test {
   public:
-    Test(std::string n, Callable exe, std::vector<std::variant<std::monostate, String, File>> args,
-         bool xfail);
+    Test(std::string n, Callable exe, std::vector<std::variant<String, File>> args, bool xfail);
 
     const std::string name;
     const Callable executable;
-    const std::vector<std::variant<std::monostate, String, File>> arguments;
+    const std::vector<std::variant<String, File>> arguments;
     const bool should_fail;
 
     /// Print a human readable version of this

--- a/src/mir/passes/argument_extractors.hpp
+++ b/src/mir/passes/argument_extractors.hpp
@@ -7,18 +7,21 @@
 
 #pragma once
 
+#include "mir.hpp"
+
 #include <optional>
 #include <variant>
 
-#include "mir.hpp"
-
 namespace MIR::Passes {
 
+/// @brief Destructure an Instruction
+/// @tparam T The type to excract
+/// @param arg the Instruction to extract from
+/// @return either the value if it is of that type, or a nullopt
 template <typename T> std::optional<T> extract_positional_argument(const Instruction & arg) {
     if (std::holds_alternative<T>(*arg.obj_ptr)) {
         return std::get<T>(*arg.obj_ptr);
     }
-    // TODO: this ignores invalid arguments
     return std::nullopt;
 }
 
@@ -43,6 +46,11 @@ std::variant<std::monostate, T, Args...> extract_positional_argument_v(const Ins
     return _extract_positional_argument_v<std::variant<std::monostate, T, Args...>, Args...>(arg);
 }
 
+/// @brief Extract a variadic number of arguments
+/// @tparam T The type to extract
+/// @param start The beging iterator to extract from
+/// @param end the end iterator to extract from
+/// @return A vector of values
 template <typename T>
 std::vector<T> extract_variadic_arguments(std::vector<Instruction>::const_iterator start,
                                           std::vector<Instruction>::const_iterator end) {
@@ -63,6 +71,11 @@ std::vector<T> extract_variadic_arguments(std::vector<Instruction>::const_iterat
     return nobjs;
 }
 
+/// @brief Extract a keyword argument from a mapping
+/// @tparam T The type to extract
+/// @param kwargs The mapping to extract from
+/// @param name the name to get
+/// @return the value associated with that name
 template <typename T>
 std::optional<T>
 extract_keyword_argument(const std::unordered_map<std::string, Instruction> & kwargs,
@@ -78,6 +91,12 @@ extract_keyword_argument(const std::unordered_map<std::string, Instruction> & kw
     return std::get<T>(*found->second.obj_ptr);
 }
 
+/// @brief Extract a keyword argument that has a variant type
+/// @tparam T The first variant type to extract
+/// @tparam ...Args additional variant types
+/// @param kwargs The mapping to extract from
+/// @param name the name to get
+/// @return the value associated with that name
 template <typename T, typename... Args>
 std::variant<std::monostate, T, Args...>
 extract_keyword_argument_v(const std::unordered_map<std::string, Instruction> & kwargs,
@@ -91,6 +110,11 @@ extract_keyword_argument_v(const std::unordered_map<std::string, Instruction> & 
     return extract_positional_argument_v<T, Args...>(found->second);
 }
 
+/// @brief Extract a keyword argument that is an array of type
+/// @tparam T The type to extract
+/// @param kwargs The mapping to extract from
+/// @param name the name to get
+/// @return the value associated with that name
 template <typename T>
 std::vector<T>
 extract_keyword_argument_a(const std::unordered_map<std::string, Instruction> & kwargs,
@@ -117,6 +141,12 @@ extract_keyword_argument_a(const std::unordered_map<std::string, Instruction> & 
     return {};
 }
 
+/// @brief Extract a keyword argument that is an array of variant types
+/// @tparam T The first variant type to extract
+/// @tparam ...Args additional variant types
+/// @param kwargs The mapping to extract from
+/// @param name the name to get
+/// @return the value associated with that name
 template <typename... Args>
 std::vector<std::variant<std::monostate, Args...>>
 extract_keyword_argument_av(const std::unordered_map<std::string, Instruction> & kwargs,

--- a/src/mir/passes/argument_extractors.hpp
+++ b/src/mir/passes/argument_extractors.hpp
@@ -155,7 +155,7 @@ extract_keyword_argument_v(const std::unordered_map<std::string, Instruction> & 
 template <typename T>
 std::vector<T>
 extract_keyword_argument_a(const std::unordered_map<std::string, Instruction> & kwargs,
-                           const std::string & name, const bool & as_list = false) {
+                           const std::string & name) {
     auto found = kwargs.find(name);
     if (found == kwargs.end()) {
         return {};

--- a/src/mir/passes/argument_extractors.hpp
+++ b/src/mir/passes/argument_extractors.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "exceptions.hpp"
 #include "mir.hpp"
 
 #include <optional>
@@ -25,6 +26,20 @@ template <typename T> std::optional<T> extract_positional_argument(const Instruc
     return std::nullopt;
 }
 
+/// @brief Extract a positional argument or fail
+/// @tparam T The type to extract
+/// @param arg the Instruction to extract from
+/// @param err_msg The error message to throw if this fails
+/// @return A copy of the instruction
+template <typename T>
+T extract_positional_argument(const Instruction & arg, const std::string & err_msg) {
+    try {
+        return std::get<T>(*arg.obj_ptr);
+    } catch (const std::bad_variant_access &) {
+        throw Util::Exceptions::InvalidArguments{err_msg};
+    }
+}
+
 template <typename R> R _extract_positional_argument_v(const Instruction & arg) {
     return std::monostate{};
 }
@@ -38,7 +53,7 @@ R _extract_positional_argument_v(const Instruction & arg) {
 }
 
 template <typename T, typename... Args>
-std::variant<std::monostate, T, Args...> extract_positional_argument_v(const Instruction & arg) {
+std::variant<T, Args...> extract_positional_argument_v(const Instruction & arg) {
     if (std::holds_alternative<T>(*arg.obj_ptr)) {
         return std::get<T>(*arg.obj_ptr);
     }

--- a/src/mir/passes/argument_extractors.hpp
+++ b/src/mir/passes/argument_extractors.hpp
@@ -95,19 +95,17 @@ std::variant<T, Args...> extract_positional_argument_v(const Instruction & arg,
 /// @return A vector of values
 template <typename T>
 std::vector<T> extract_variadic_arguments(std::vector<Instruction>::const_iterator start,
-                                          std::vector<Instruction>::const_iterator end) {
+                                          std::vector<Instruction>::const_iterator end,
+                                          const std::string & err_msg) {
     std::vector<T> nobjs{};
     for (; start != end; start++) {
         if (std::holds_alternative<Array>(*start->obj_ptr)) {
             const auto & arr = std::get<Array>(*start->obj_ptr);
-            const auto & nvals = extract_variadic_arguments<T>(arr.value.begin(), arr.value.end());
+            const auto & nvals =
+                extract_variadic_arguments<T>(arr.value.begin(), arr.value.end(), err_msg);
             nobjs.insert(nobjs.end(), nvals.begin(), nvals.end());
         } else {
-            // TODO: this is going to ignore invalid arghuments
-            std::optional<T> arg = extract_positional_argument<T>(*start->obj_ptr);
-            if (arg) {
-                nobjs.emplace_back(arg.value());
-            }
+            nobjs.emplace_back(extract_positional_argument<T>(*start->obj_ptr, err_msg));
         }
     }
     return nobjs;

--- a/src/mir/passes/argument_extractors.hpp
+++ b/src/mir/passes/argument_extractors.hpp
@@ -115,20 +115,17 @@ std::vector<T> extract_variadic_arguments(std::vector<Instruction>::const_iterat
 /// @tparam T The type to extract
 /// @param kwargs The mapping to extract from
 /// @param name the name to get
+/// @param err_msg The message to throw if the argument is of the incorrect type
 /// @return the value associated with that name
 template <typename T>
 std::optional<T>
 extract_keyword_argument(const std::unordered_map<std::string, Instruction> & kwargs,
-                         const std::string & name) {
+                         const std::string & name, const std::string & err_msg) {
     const auto & found = kwargs.find(name);
     if (found == kwargs.end()) {
         return std::nullopt;
     }
-    if (!std::holds_alternative<T>(*found->second.obj_ptr)) {
-        // XXX: this is just going to ignore invalid arguments…
-        return std::nullopt;
-    }
-    return std::get<T>(*found->second.obj_ptr);
+    return extract_positional_argument<T>(found->second, err_msg);
 }
 
 /// @brief Extract a keyword argument that has a variant type

--- a/src/mir/passes/argument_extractors.hpp
+++ b/src/mir/passes/argument_extractors.hpp
@@ -41,6 +41,7 @@ T extract_positional_argument(const Instruction & arg, const std::string & err_m
 }
 
 template <typename R> R _extract_positional_argument_v(const Instruction & arg) {
+    // TODO: this ignores invalid arguments
     return std::monostate{};
 }
 
@@ -52,13 +53,14 @@ R _extract_positional_argument_v(const Instruction & arg) {
     return _extract_positional_argument_v<R, Args...>(arg);
 }
 
+/// @brief Extract a positional argument that is a variadic type
+/// @tparam T The first type to try
+/// @tparam ...Args additional types to try
+/// @param arg The Instruction to extract from
+/// @return The argument or a mononstate if the type is missing
 template <typename T, typename... Args>
-std::variant<T, Args...> extract_positional_argument_v(const Instruction & arg) {
-    if (std::holds_alternative<T>(*arg.obj_ptr)) {
-        return std::get<T>(*arg.obj_ptr);
-    }
-    // TODO: this ignores invalid arguments
-    return _extract_positional_argument_v<std::variant<std::monostate, T, Args...>, Args...>(arg);
+std::variant<std::monostate, T, Args...> extract_positional_argument_v(const Instruction & arg) {
+    return _extract_positional_argument_v<std::variant<std::monostate, T, Args...>, T, Args...>(arg);
 }
 
 /// @brief Extract a variadic number of arguments

--- a/src/mir/passes/argument_extractors.hpp
+++ b/src/mir/passes/argument_extractors.hpp
@@ -181,24 +181,23 @@ extract_keyword_argument_a(const std::unordered_map<std::string, Instruction> & 
 /// @param name the name to get
 /// @return the value associated with that name
 template <typename... Args>
-std::vector<std::variant<std::monostate, Args...>>
+std::optional<std::vector<std::variant<Args...>>>
 extract_keyword_argument_av(const std::unordered_map<std::string, Instruction> & kwargs,
-                            const std::string & name) {
-    // FIXME: this has the same problem as the other version, which is that you
-    // can't distinguish between "not present" and "not a valid type"
+                            const std::string & name, const std::string & err_msg) {
     const auto & found = kwargs.find(name);
     if (found == kwargs.end()) {
-        return {};
+        return std::nullopt;
     }
     if (auto v = std::get_if<Array>(found->second.obj_ptr.get())) {
-        std::vector<std::variant<std::monostate, Args...>> ret{};
+        std::vector<std::variant<Args...>> ret{};
         for (const auto & a : v->value) {
             // XXX: also ignores invalid arguments
-            ret.emplace_back(extract_positional_argument_v<Args...>(a));
+            ret.emplace_back(extract_positional_argument_v<Args...>(a, err_msg));
         }
         return ret;
     }
-    return {extract_positional_argument_v<Args...>(found->second)};
+    return std::vector<std::variant<Args...>>{
+        extract_positional_argument_v<Args...>(found->second, err_msg)};
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/argument_extractors.hpp
+++ b/src/mir/passes/argument_extractors.hpp
@@ -41,7 +41,6 @@ T extract_positional_argument(const Instruction & arg, const std::string & err_m
 }
 
 template <typename R> R _extract_positional_argument_v(const Instruction & arg) {
-    // TODO: this ignores invalid arguments
     return std::monostate{};
 }
 
@@ -60,7 +59,33 @@ R _extract_positional_argument_v(const Instruction & arg) {
 /// @return The argument or a mononstate if the type is missing
 template <typename T, typename... Args>
 std::variant<std::monostate, T, Args...> extract_positional_argument_v(const Instruction & arg) {
-    return _extract_positional_argument_v<std::variant<std::monostate, T, Args...>, T, Args...>(arg);
+    return _extract_positional_argument_v<std::variant<std::monostate, T, Args...>, T, Args...>(
+        arg);
+}
+
+template <typename R>
+R _extract_positional_argument_v(const Instruction & arg, const std::string & err_msg) {
+    throw Util::Exceptions::InvalidArguments{err_msg};
+}
+
+template <typename R, typename T, typename... Args>
+R _extract_positional_argument_v(const Instruction & arg, const std::string & err_msg) {
+    if (std::holds_alternative<T>(*arg.obj_ptr)) {
+        return std::get<T>(*arg.obj_ptr);
+    }
+    return _extract_positional_argument_v<R, Args...>(arg, err_msg);
+}
+
+/// @brief Extract a positional argument that is a variadic type
+/// @tparam T The first type to try
+/// @tparam ...Args additional types to try
+/// @param arg The Instruction to extract from
+/// @param err_msg a message to add to an exception if the variant cannot be found
+/// @return The argument or a mononstate if the type is missing
+template <typename T, typename... Args>
+std::variant<T, Args...> extract_positional_argument_v(const Instruction & arg,
+                                                       const std::string & err_msg) {
+    return _extract_positional_argument_v<std::variant<T, Args...>, T, Args...>(arg, err_msg);
 }
 
 /// @brief Extract a variadic number of arguments

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -102,8 +102,7 @@ std::optional<T> lower_build_target(const FunctionCall & f, const State::Persist
         slink.emplace_back(StaticLinkMode::NORMAL, s);
     }
 
-    auto raw_inc =
-        extract_keyword_argument_a<IncludeDirectories>(f.kw_args, "include_directories", true);
+    auto raw_inc = extract_keyword_argument_a<IncludeDirectories>(f.kw_args, "include_directories");
     for (const auto & i : raw_inc) {
         for (const auto & d : i.directories) {
             args[Toolchain::Language::CPP].emplace_back(d, Arguments::Type::INCLUDE,

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -333,7 +333,10 @@ std::optional<Instruction> lower_declare_dependency(const FunctionCall & f,
     }
 
     const auto & raw_inc_args =
-        extract_keyword_argument_av<String, IncludeDirectories>(f.kw_args, "include_directories");
+        extract_keyword_argument_av<String, IncludeDirectories>(
+            f.kw_args, "include_directories",
+            f.name + ": 'include_directories' must be strings or IncludeDirectories objects")
+            .value_or(std::vector<std::variant<String, IncludeDirectories>>{});
 
     for (const auto & i : raw_inc_args) {
         if (std::holds_alternative<String>(i)) {
@@ -389,7 +392,10 @@ std::optional<Instruction> lower_test(const FunctionCall & f, const State::Persi
     const Callable & prog = std::visit(CallableReducer{}, prog_v);
 
     // TODO: Also allows targets
-    auto && arguments = extract_keyword_argument_av<MIR::String, MIR::File>(f.kw_args, "args");
+    auto && arguments =
+        extract_keyword_argument_av<MIR::String, MIR::File>(
+            f.kw_args, "args", f.name + ": 'args' keyword arguments must be strings or files")
+            .value_or(std::vector<std::variant<String, File>>{});
 
     const bool xfail =
         extract_keyword_argument<MIR::Boolean>(f.kw_args, "should_fail",

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -138,7 +138,9 @@ std::optional<Instruction> lower_include_dirs(const FunctionCall & f,
     }
 
     auto is_system =
-        extract_keyword_argument<Boolean>(f.kw_args, "is_system").value_or(Boolean{false});
+        extract_keyword_argument<Boolean>(
+            f.kw_args, "is_system", "include_directories: 'is_system' argument must be a boolean")
+            .value_or(Boolean{false});
 
     return IncludeDirectories{dirs, is_system.value};
 }
@@ -294,7 +296,10 @@ std::optional<Instruction> lower_declare_dependency(const FunctionCall & f,
     }
 
     std::string version =
-        extract_keyword_argument<String>(f.kw_args, "version").value_or(String("unknown")).value;
+        extract_keyword_argument<String>(
+            f.kw_args, "version", "declare_dependency: 'version' keyword argument must be a string")
+            .value_or(String("unknown"))
+            .value;
 
     std::vector<Arguments::Argument> args{};
     const auto & raw_comp_args = extract_keyword_argument_a<String>(f.kw_args, "compile_args");
@@ -369,9 +374,11 @@ std::optional<Instruction> lower_test(const FunctionCall & f, const State::Persi
     // TODO: Also allows targets
     auto && arguments = extract_keyword_argument_av<MIR::String, MIR::File>(f.kw_args, "args");
 
-    const bool xfail = extract_keyword_argument<MIR::Boolean>(f.kw_args, "should_fail")
-                           .value_or(MIR::Boolean{false})
-                           .value;
+    const bool xfail =
+        extract_keyword_argument<MIR::Boolean>(f.kw_args, "should_fail",
+                                               "test: 'should_fail' argument must be a boolean")
+            .value_or(MIR::Boolean{false})
+            .value;
 
     return Test{name.value, prog, arguments, xfail};
 }

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -360,8 +360,8 @@ std::optional<Instruction> lower_test(const FunctionCall & f, const State::Persi
         f.pos_args.at(0), f.name + ": first argument must be a string");
 
     // TODO: should also allow CustomTarget and Jar
-    auto && prog_v =
-        extract_positional_argument_v<MIR::File, MIR::Program, MIR::Executable>(f.pos_args.at(1));
+    auto && prog_v = extract_positional_argument_v<MIR::File, MIR::Program, MIR::Executable>(
+        f.pos_args.at(1), f.name + ": got an invalid type for program");
     const Callable & prog = std::visit(CallableReducer{}, prog_v);
 
     // TODO: Also allows targets

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -16,7 +16,8 @@ namespace MIR::Passes {
 namespace {
 
 std::optional<Instruction> lower_files(const FunctionCall & f, const State::Persistant & pstate) {
-    auto args = extract_variadic_arguments<String>(f.pos_args.begin(), f.pos_args.end());
+    auto args = extract_variadic_arguments<String>(f.pos_args.begin(), f.pos_args.end(),
+                                                   "files: arguments must be strings");
     std::vector<Instruction> files{};
     files.reserve(args.size());
     std::transform(args.begin(), args.end(), std::back_inserter(files), [&](const String & v) {
@@ -154,7 +155,8 @@ std::optional<Instruction> lower_messages(const FunctionCall & f) {
 
     // TODO: Meson accepts anything as a message bascially, without flattening.
     // Currently, Meson++ flattens everything so I'm only going to allow strings for the moment.
-    auto args = extract_variadic_arguments<String>(f.pos_args.begin(), f.pos_args.end());
+    auto args = extract_variadic_arguments<String>(f.pos_args.begin(), f.pos_args.end(),
+                                                   "message: arguments must be strings");
 
     std::string message{};
     for (const auto & a : args) {
@@ -508,8 +510,9 @@ std::optional<Instruction> lower_add_arguments(const FunctionCall & func, const 
         throw Util::Exceptions::MesonException(func.name + ": missing required kwarg 'language'");
     }
 
-    const std::vector<MIR::String> arguments =
-        extract_variadic_arguments<MIR::String>(func.pos_args.begin(), func.pos_args.end());
+    const std::vector<MIR::String> arguments = extract_variadic_arguments<MIR::String>(
+        func.pos_args.begin(), func.pos_args.end(),
+        func.name + ": positional arguments must be strings");
     // Meson allows this, so if we don't get any arguments, just return an empty to delete the node
     if (arguments.empty()) {
         return Empty{};
@@ -665,7 +668,8 @@ void lower_project(BasicBlock & block, State::Persistant & pstate) {
     // TODO: I don't want this in here, I'd rather have this all done in the backend, I think
     std::cout << "Project name: " << Util::Log::bold(pstate.name) << std::endl;
 
-    const auto & langs = extract_variadic_arguments<String>(++pos, f.pos_args.end());
+    const auto & langs = extract_variadic_arguments<String>(
+        ++pos, f.pos_args.end(), "project: Language arguments must be strings");
     for (const auto & lang : langs) {
         const auto l = Toolchain::from_string(lang.value);
 

--- a/src/mir/passes/string_objects.cpp
+++ b/src/mir/passes/string_objects.cpp
@@ -24,7 +24,8 @@ std::optional<Instruction> lower_version_compare_method(const FunctionCall & f) 
     }
 
     // XXX: really need to check that this has a value...
-    const auto c = extract_positional_argument<String>(f.pos_args[0]).value();
+    const auto c = extract_positional_argument<String>(
+        f.pos_args[0], "string.version_compare: First argument was not a string");
     const auto & s = std::get<String>(*f.holder.obj_ptr);
 
     std::string cval{};

--- a/src/mir/passes/tests/custom_target_program_replacement_test.cpp
+++ b/src/mir/passes/tests/custom_target_program_replacement_test.cpp
@@ -59,7 +59,7 @@ TEST(custom_target_program_replacement, array) {
     EXPECT_EQ(cmd0.name, "find_program");
 
     ASSERT_EQ(cmd0.pos_args.size(), 1);
-    const auto & arg_o = MIR::Passes::extract_positional_argument<MIR::String>(cmd0.pos_args.at(0));
-    ASSERT_TRUE(arg_o.has_value());
-    ASSERT_EQ(arg_o.value().value, "foo.py");
+    const auto & arg_o =
+        MIR::Passes::extract_positional_argument<MIR::String>(cmd0.pos_args.at(0), "Error!");
+    ASSERT_EQ(arg_o.value, "foo.py");
 }

--- a/src/mir/passes/tests/custom_target_program_replacement_test.cpp
+++ b/src/mir/passes/tests/custom_target_program_replacement_test.cpp
@@ -21,8 +21,7 @@ TEST(custom_target_program_replacement, string) {
     const auto & fc = std::get<MIR::FunctionCall>(*fc_obj.obj_ptr);
 
     const auto & commands_o =
-        MIR::Passes::extract_keyword_argument<MIR::Array>(fc.kw_args, "command");
-    ASSERT_TRUE(commands_o.has_value());
+        MIR::Passes::extract_keyword_argument<MIR::Array>(fc.kw_args, "command", "Error!");
 
     const auto & commands = commands_o.value();
     ASSERT_EQ(commands.value.size(), 1);
@@ -49,7 +48,7 @@ TEST(custom_target_program_replacement, array) {
     const auto & fc = std::get<MIR::FunctionCall>(*fc_obj.obj_ptr);
 
     const auto & commands_o =
-        MIR::Passes::extract_keyword_argument<MIR::Array>(fc.kw_args, "command");
+        MIR::Passes::extract_keyword_argument<MIR::Array>(fc.kw_args, "command", "Error!");
     ASSERT_TRUE(commands_o.has_value());
 
     const auto & commands = commands_o.value();

--- a/src/mir/passes/threaded.cpp
+++ b/src/mir/passes/threaded.cpp
@@ -164,7 +164,7 @@ void search_for_threaded_impl(FindList & jobs, State::Persistant & pstate) {
 std::optional<Instruction> replace_find_program(const FunctionCall & f, State::Persistant & state) {
     // We know this is safe since we've already processed this call before (hopefully)
     // We only need the first name, as all of the names should be in the mapping
-    auto name = extract_positional_argument<String>(f.pos_args[0]).value().value;
+    auto name = extract_positional_argument<String>(f.pos_args[0], f.name + ": first argument was not a string").value;
 
     fs::path exe;
     try {

--- a/src/mir/passes/threaded.cpp
+++ b/src/mir/passes/threaded.cpp
@@ -177,7 +177,10 @@ std::optional<Instruction> replace_find_program(const FunctionCall & f, State::P
     }
 
     bool required =
-        extract_keyword_argument<Boolean>(f.kw_args, "required").value_or(Boolean{true}).value;
+        extract_keyword_argument<Boolean>(
+            f.kw_args, "required", "find_program: 'required' keyword argument must be a boolean")
+            .value_or(Boolean{true})
+            .value;
     if (required && exe == "") {
         throw Util::Exceptions::MesonException("Could not find required program \"" + name + "\"");
     }

--- a/src/mir/passes/threaded.cpp
+++ b/src/mir/passes/threaded.cpp
@@ -106,7 +106,8 @@ class FindList {
 };
 
 bool search_find_program(const FunctionCall & f, State::Persistant & pstate, FindList & jobs) {
-    auto names = extract_variadic_arguments<String>(f.pos_args.begin(), f.pos_args.end());
+    auto names = extract_variadic_arguments<String>(f.pos_args.begin(), f.pos_args.end(),
+                                                    "find_program: names must be strings");
 
     std::vector<std::string> ret{names.size()};
     std::transform(names.begin(), names.end(), ret.begin(),
@@ -164,7 +165,9 @@ void search_for_threaded_impl(FindList & jobs, State::Persistant & pstate) {
 std::optional<Instruction> replace_find_program(const FunctionCall & f, State::Persistant & state) {
     // We know this is safe since we've already processed this call before (hopefully)
     // We only need the first name, as all of the names should be in the mapping
-    auto name = extract_positional_argument<String>(f.pos_args[0], f.name + ": first argument was not a string").value;
+    auto name = extract_positional_argument<String>(f.pos_args[0],
+                                                    f.name + ": first argument was not a string")
+                    .value;
 
     fs::path exe;
     try {


### PR DESCRIPTION
Throw errors when the types are invalid, be more specific about missing vs empty arrays.