### PR TITLE
Completely rework control flow

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2021 Intel Corporation
+# Copyright © 2021-2024 Intel Corporation
 
 project(
   'meson++',
@@ -7,7 +7,7 @@ project(
   version : '0.0.1',
   meson_version : '>= 0.55',
   license : 'Apache-2.0',
-  default_options : ['cpp_std=c++17', 'c_std=c99']
+  default_options : ['cpp_std=c++17', 'c_std=c99'],
 )
 
 cpp = meson.get_compiler('cpp')
@@ -32,7 +32,12 @@ elif cpp.get_id() == 'clang'
   dep_fs = cpp.find_library('c++fs', required : false)
 endif
 
-dep_gtest = dependency('gtest_main', disabler : true, required : get_option('tests'), fallback : ['gtest', 'gtest_main_dep'])
+dep_gtest = dependency(
+  'gtest_main',
+  disabler : true,
+  required : get_option('tests'),
+  fallback : ['gtest', 'gtest_main_dep'],
+)
 
 subdir('src')
 subdir('tests')

--- a/muon_fmt.ini
+++ b/muon_fmt.ini
@@ -1,0 +1,1 @@
+wide_colon = true

--- a/src/backends/fir/fir.hpp
+++ b/src/backends/fir/fir.hpp
@@ -78,6 +78,6 @@ class Target {
 };
 
 std::tuple<std::vector<Target>, std::vector<Common::Test>>
-mir_to_fir(const MIR::BasicBlock & block, const MIR::State::Persistant & pstate);
+mir_to_fir(const MIR::CFGNode & block, const MIR::State::Persistant & pstate);
 
 } // namespace Backends::FIR

--- a/src/backends/fir/mir_to_fir.cpp
+++ b/src/backends/fir/mir_to_fir.cpp
@@ -215,7 +215,7 @@ std::tuple<std::vector<Target>, std::vector<Common::Test>>
 mir_to_fir(const MIR::CFGNode & block, const MIR::State::Persistant & pstate) {
     State state{};
     // Process the instructions that alter state
-    for (const auto & i : block.instructions) {
+    for (const auto & i : block.block->instructions) {
         if (std::holds_alternative<MIR::AddArguments>(*i.obj_ptr)) {
             // TODO: actually handle global vs per-project
             const auto & argmap = std::get<MIR::AddArguments>(*i.obj_ptr);
@@ -230,7 +230,7 @@ mir_to_fir(const MIR::CFGNode & block, const MIR::State::Persistant & pstate) {
     std::vector<Target> rules{};
     std::vector<Common::Test> tests{};
 
-    for (const auto & i : block.instructions) {
+    for (const auto & i : block.block->instructions) {
         if (std::holds_alternative<MIR::Executable>(*i.obj_ptr)) {
             auto r = target_rule(std::get<MIR::Executable>(*i.obj_ptr), pstate, state);
             std::move(r.begin(), r.end(), std::back_inserter(rules));

--- a/src/backends/fir/mir_to_fir.cpp
+++ b/src/backends/fir/mir_to_fir.cpp
@@ -212,7 +212,7 @@ Common::Test target_test(const MIR::Test & t, const MIR::State::Persistant & pst
 } // namespace
 
 std::tuple<std::vector<Target>, std::vector<Common::Test>>
-mir_to_fir(const MIR::BasicBlock & block, const MIR::State::Persistant & pstate) {
+mir_to_fir(const MIR::CFGNode & block, const MIR::State::Persistant & pstate) {
     State state{};
     // Process the instructions that alter state
     for (const auto & i : block.instructions) {

--- a/src/backends/ninja/entry.hpp
+++ b/src/backends/ninja/entry.hpp
@@ -15,6 +15,6 @@ namespace Backends::Ninja {
 /**
  * Generates a ninja file in the build directory
  */
-void generate(const MIR::BasicBlock &, const MIR::State::Persistant &);
+void generate(const MIR::CFGNode &, const MIR::State::Persistant &);
 
 } // namespace Backends::Ninja

--- a/src/backends/ninja/ninja.cpp
+++ b/src/backends/ninja/ninja.cpp
@@ -205,7 +205,7 @@ void write_build_rule(const FIR::Target & rule, std::ofstream & out) {
 
 } // namespace
 
-void generate(const MIR::BasicBlock & block, const MIR::State::Persistant & pstate) {
+void generate(const MIR::CFGNode & block, const MIR::State::Persistant & pstate) {
     if (!fs::exists(pstate.build_root)) {
         std::error_code ec{};
         fs::create_directory(pstate.build_root, ec);

--- a/src/frontend/node.cpp
+++ b/src/frontend/node.cpp
@@ -24,45 +24,7 @@ struct ExprStringVisitor {
         return std::visit(as, s->lhs) + "[" + std::visit(as, s->rhs) + "]";
     }
 
-    std::string operator()(const std::unique_ptr<Relational> & s) {
-        ExprStringVisitor as{};
-
-        std::string opstr{};
-        switch (s->op) {
-            case RelationalOp::LT:
-                opstr = "<";
-                break;
-            case RelationalOp::LE:
-                opstr = "<=";
-                break;
-            case RelationalOp::EQ:
-                opstr = "==";
-                break;
-            case RelationalOp::NE:
-                opstr = "!=";
-                break;
-            case RelationalOp::GE:
-                opstr = ">=";
-                break;
-            case RelationalOp::GT:
-                opstr = ">";
-                break;
-            case RelationalOp::AND:
-                opstr = "and";
-                break;
-            case RelationalOp::OR:
-                opstr = "or";
-                break;
-            case RelationalOp::IN:
-                opstr = "in";
-                break;
-            case RelationalOp::NOT_IN:
-                opstr = "not in";
-                break;
-        }
-
-        return std::visit(as, s->lhs) + " " + opstr + " " + std::visit(as, s->rhs);
-    }
+    std::string operator()(const std::unique_ptr<Relational> & s) { return s->as_string(); }
 
     std::string operator()(const std::unique_ptr<UnaryExpression> & s) {
         // There's currently only unary negation
@@ -239,6 +201,45 @@ std::string GetAttribute::as_string() const {
     auto obj = std::visit(as, holder);
     auto name = std::visit(as, held);
     return obj + "." + name;
+}
+
+std::string Relational::as_string() const {
+    std::string opstr{};
+    switch (op) {
+        case RelationalOp::LT:
+            opstr = "<";
+            break;
+        case RelationalOp::LE:
+            opstr = "<=";
+            break;
+        case RelationalOp::EQ:
+            opstr = "==";
+            break;
+        case RelationalOp::NE:
+            opstr = "!=";
+            break;
+        case RelationalOp::GE:
+            opstr = ">=";
+            break;
+        case RelationalOp::GT:
+            opstr = ">";
+            break;
+        case RelationalOp::AND:
+            opstr = "and";
+            break;
+        case RelationalOp::OR:
+            opstr = "or";
+            break;
+        case RelationalOp::IN:
+            opstr = "in";
+            break;
+        case RelationalOp::NOT_IN:
+            opstr = "not in";
+            break;
+    }
+
+    ExprStringVisitor as{};
+    return std::visit(as, lhs) + " " + opstr + " " + std::visit(as, rhs);
 }
 
 std::string Array::as_string() const { return "[" + stringlistify(elements) + "]"; }

--- a/src/frontend/parser.yy
+++ b/src/frontend/parser.yy
@@ -84,9 +84,9 @@
 %right                  NOT
 %left                   "-" "+"
 %left                   "*" "/" "%"
+%left                   RELATIONAL  // XXX: is the priority of this off?
 %left                   "."
 %left                   "(" ")" "[" "]"
-%left                   RELATIONAL  // XXX: is the priority of this off?
 %left                   "\n"
 %nonassoc               "?" ":"
 %nonassoc               IF ELIF ELSE ENDIF

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,8 +68,8 @@ int configure(const Options::ConfigureOptions & opts) {
 
     // Create IR from the AST, then run our lowering passes on it
     auto irlist = MIR::lower_ast(block, pstate);
-    MIR::Passes::lower_project(*irlist, pstate);
-    MIR::lower(*irlist, pstate);
+    MIR::Passes::lower_project(irlist, pstate);
+    MIR::lower(irlist, pstate);
 
     const bool errors = emit_messages(*irlist);
     if (errors) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ namespace fs = std::filesystem;
 
 namespace {
 
-bool emit_messages(MIR::BasicBlock & block) {
+bool emit_messages(MIR::CFGNode & block) {
     static std::vector<MIR::MessageLevel> levels{MIR::MessageLevel::MESSAGE,
                                                  MIR::MessageLevel::WARN, MIR::MessageLevel::ERROR};
     bool errors = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ bool emit_messages(MIR::CFGNode & block) {
         } else if (level == MIR::MessageLevel::DEBUG) {
             std::cout << Util::Log::bold("Debug information:") << std::endl;
         }
-        for (const auto & i : block.instructions) {
+        for (const auto & i : block.block->instructions) {
             if (std::holds_alternative<MIR::Message>(*i.obj_ptr)) {
                 const auto & m = std::get<MIR::Message>(*i.obj_ptr);
                 if (m.level == level) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,16 +67,16 @@ int configure(const Options::ConfigureOptions & opts) {
     MIR::State::Persistant pstate{opts.sourcedir, opts.builddir, opts.program};
 
     // Create IR from the AST, then run our lowering passes on it
-    auto irlist = MIR::lower_ast(block, pstate);
-    MIR::Passes::lower_project(irlist, pstate);
-    MIR::lower(irlist, pstate);
+    MIR::CFG irlist = MIR::lower_ast(block, pstate);
+    MIR::Passes::lower_project(irlist.root, pstate);
+    MIR::lower(irlist.root, pstate);
 
-    const bool errors = emit_messages(*irlist);
+    const bool errors = emit_messages(*irlist.root);
     if (errors) {
         throw Util::Exceptions::MesonException("Configure failed with errors.");
     }
 
-    Backends::Ninja::generate(*irlist, pstate);
+    Backends::Ninja::generate(*irlist.root, pstate);
 
     return 0;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,15 +68,15 @@ int configure(const Options::ConfigureOptions & opts) {
 
     // Create IR from the AST, then run our lowering passes on it
     auto irlist = MIR::lower_ast(block, pstate);
-    MIR::Passes::lower_project(irlist, pstate);
-    MIR::lower(irlist, pstate);
+    MIR::Passes::lower_project(*irlist, pstate);
+    MIR::lower(*irlist, pstate);
 
-    const bool errors = emit_messages(irlist);
+    const bool errors = emit_messages(*irlist);
     if (errors) {
         throw Util::Exceptions::MesonException("Configure failed with errors.");
     }
 
-    Backends::Ninja::generate(irlist, pstate);
+    Backends::Ninja::generate(*irlist, pstate);
 
     return 0;
 };

--- a/src/mir/ast_to_mir.cpp
+++ b/src/mir/ast_to_mir.cpp
@@ -196,6 +196,11 @@ struct ExpressionLowering {
     };
 };
 
+inline void link_blocks(std::shared_ptr<BasicBlock> predecessor,
+                        std::shared_ptr<BasicBlock> successor) {
+    successor->predecessors.emplace(predecessor.get());
+}
+
 /**
  * Lowers AST statements into MIR objects.
  */
@@ -238,7 +243,7 @@ struct StatementLowering {
         auto * cur = std::get<std::unique_ptr<Condition>>(list->next).get();
 
         last_block = cur->if_true;
-        last_block->predecessors.emplace(list.get());
+        link_blocks(list, last_block);
 
         // Walk over the statements, adding them to the if_true branch.
         for (const auto & i : stmt->ifblock.block->statements) {
@@ -253,7 +258,7 @@ struct StatementLowering {
         // We shouldn't have a condition here, this is where we wnat to put our next target
         assert(std::holds_alternative<std::monostate>(last_block->next));
         last_block->next = next_block;
-        next_block->predecessors.emplace(last_block.get());
+        link_blocks(last_block, next_block);
 
         // for each elif branch create a new condition in the `else` of the
         // Condition, then assign the condition to the `if_true`. Then go down
@@ -262,7 +267,7 @@ struct StatementLowering {
             for (const auto & el : stmt->efblock) {
                 cur->if_false = std::make_shared<BasicBlock>(
                     std::make_unique<Condition>(std::visit(l, el.condition)));
-                cur->if_false->predecessors.emplace(list.get());
+                link_blocks(list, cur->if_false);
                 cur = std::get<std::unique_ptr<Condition>>(cur->if_false->next).get();
                 last_block = cur->if_true;
 
@@ -273,7 +278,7 @@ struct StatementLowering {
 
                 assert(!std::holds_alternative<std::unique_ptr<Condition>>(last_block->next));
                 last_block->next = next_block;
-                next_block->predecessors.emplace(last_block.get());
+                link_blocks(last_block, next_block);
             }
         }
 
@@ -282,21 +287,21 @@ struct StatementLowering {
             assert(cur->if_false == nullptr);
             cur->if_false = std::make_shared<BasicBlock>();
             last_block = cur->if_false;
-            last_block->predecessors.emplace(list.get());
+            link_blocks(list, last_block);
             for (const auto & i : stmt->eblock.block->statements) {
                 last_block =
                     std::visit([&](const auto & a) { return this->operator()(last_block, a); }, i);
             }
             assert(!std::holds_alternative<std::unique_ptr<Condition>>(last_block->next));
             last_block->next = next_block;
-            next_block->predecessors.emplace(last_block.get());
+            link_blocks(last_block, next_block);
         } else {
             // If we don't have an else, create a false one by putting hte next
             // block in it. this means taht if we don't go down any of the
             // branches that we proceed on correctly
             assert(cur->if_false == nullptr);
             cur->if_false = next_block;
-            next_block->predecessors.emplace(list.get());
+            link_blocks(list, next_block);
         }
 
         assert(std::holds_alternative<std::monostate>(next_block->next));

--- a/src/mir/ast_to_mir.cpp
+++ b/src/mir/ast_to_mir.cpp
@@ -198,7 +198,8 @@ struct ExpressionLowering {
 
 inline void link_blocks(std::shared_ptr<BasicBlock> predecessor,
                         std::shared_ptr<BasicBlock> successor) {
-    successor->predecessors.emplace(predecessor.get());
+    successor->predecessors.emplace(predecessor);
+    predecessor->successors.emplace(successor);
 }
 
 /**

--- a/src/mir/ast_to_mir.cpp
+++ b/src/mir/ast_to_mir.cpp
@@ -359,8 +359,8 @@ struct StatementLowering {
 /**
  * Lower AST representation into MIR.
  */
-std::shared_ptr<CFGNode> lower_ast(const std::unique_ptr<Frontend::AST::CodeBlock> & block,
-                                   const MIR::State::Persistant & pstate) {
+CFG lower_ast(const std::unique_ptr<Frontend::AST::CodeBlock> & block,
+              const MIR::State::Persistant & pstate) {
     auto root_block = std::make_shared<CFGNode>();
     auto current_block = root_block;
     const StatementLowering lower{pstate};
@@ -368,7 +368,7 @@ std::shared_ptr<CFGNode> lower_ast(const std::unique_ptr<Frontend::AST::CodeBloc
         current_block = std::visit([&](const auto & a) { return lower(current_block, a); }, i);
     }
 
-    return root_block;
+    return CFG{root_block};
 }
 
 } // namespace MIR

--- a/src/mir/ast_to_mir.cpp
+++ b/src/mir/ast_to_mir.cpp
@@ -215,7 +215,7 @@ struct StatementLowering {
                const std::unique_ptr<Frontend::AST::Statement> & stmt) const {
         assert(std::holds_alternative<std::monostate>(list->next));
         const ExpressionLowering l{pstate};
-        list->instructions.emplace_back(std::visit(l, stmt->expr));
+        list->block->instructions.emplace_back(std::visit(l, stmt->expr));
         assert(std::holds_alternative<std::monostate>(list->next));
         return list;
     };
@@ -329,7 +329,7 @@ struct StatementLowering {
         }
         value.var.name = name_ptr->value;
 
-        list->instructions.emplace_back(std::move(value));
+        list->block->instructions.emplace_back(std::move(value));
         assert(std::holds_alternative<std::monostate>(list->next));
         return list;
     };

--- a/src/mir/ast_to_mir.cpp
+++ b/src/mir/ast_to_mir.cpp
@@ -196,11 +196,6 @@ struct ExpressionLowering {
     };
 };
 
-inline void link_blocks(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor) {
-    successor->predecessors.emplace(predecessor);
-    predecessor->successors.emplace(successor);
-}
-
 /**
  * Lowers AST statements into MIR objects.
  */

--- a/src/mir/ast_to_mir.hpp
+++ b/src/mir/ast_to_mir.hpp
@@ -12,7 +12,6 @@
 namespace MIR {
 
 /// Lower AST to IR
-std::shared_ptr<CFGNode> lower_ast(const std::unique_ptr<Frontend::AST::CodeBlock> &,
-                                   const MIR::State::Persistant &);
+CFG lower_ast(const std::unique_ptr<Frontend::AST::CodeBlock> &, const MIR::State::Persistant &);
 
 }; // namespace MIR

--- a/src/mir/ast_to_mir.hpp
+++ b/src/mir/ast_to_mir.hpp
@@ -7,10 +7,12 @@
 #include "node.hpp"
 #include "state/state.hpp"
 
+#include <memory>
+
 namespace MIR {
 
 /// Lower AST to IR
-BasicBlock lower_ast(const std::unique_ptr<Frontend::AST::CodeBlock> &,
-                     const MIR::State::Persistant &);
+std::shared_ptr<BasicBlock> lower_ast(const std::unique_ptr<Frontend::AST::CodeBlock> &,
+                                      const MIR::State::Persistant &);
 
 }; // namespace MIR

--- a/src/mir/ast_to_mir.hpp
+++ b/src/mir/ast_to_mir.hpp
@@ -12,7 +12,7 @@
 namespace MIR {
 
 /// Lower AST to IR
-std::shared_ptr<BasicBlock> lower_ast(const std::unique_ptr<Frontend::AST::CodeBlock> &,
-                                      const MIR::State::Persistant &);
+std::shared_ptr<CFGNode> lower_ast(const std::unique_ptr<Frontend::AST::CodeBlock> &,
+                                   const MIR::State::Persistant &);
 
 }; // namespace MIR

--- a/src/mir/ast_to_mir_test.cpp
+++ b/src/mir/ast_to_mir_test.cpp
@@ -153,6 +153,16 @@ TEST(ast_to_ir, chained_method) {
     ASSERT_TRUE(std::holds_alternative<MIR::Identifier>(*ir2.holder.obj_ptr));
 }
 
+TEST(ast_to_ir, method_in_function) {
+    auto irlist = lower("obj.method() == 0");
+    const auto & obj = irlist->block->instructions.front();
+    ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
+    const auto & eq = std::get<MIR::FunctionCall>(obj.object());
+    ASSERT_EQ(eq.name, "rel_eq");
+    ASSERT_EQ(eq.pos_args.size(), 2);
+    ASSERT_TRUE(std::holds_alternative<std::monostate>(eq.holder.object()));
+}
+
 TEST(ast_to_ir, function_positional_arguments_only) {
     auto irlist = lower("has_args(1, 2, 3)");
     ASSERT_EQ(irlist.instructions.size(), 1);

--- a/src/mir/ast_to_mir_test.cpp
+++ b/src/mir/ast_to_mir_test.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<MIR::CFGNode> lower(const std::string & in) {
     auto block = parse(in);
     const MIR::State::Persistant pstate{"foo/src", "foo/build", ""};
     auto ir = MIR::lower_ast(block, pstate);
-    return ir;
+    return ir.root;
 }
 
 inline bool is_bb(const MIR::NextType & next) {

--- a/src/mir/ast_to_mir_test.cpp
+++ b/src/mir/ast_to_mir_test.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<Frontend::AST::CodeBlock> parse(const std::string & in) {
     return block;
 }
 
-std::shared_ptr<MIR::BasicBlock> lower(const std::string & in) {
+std::shared_ptr<MIR::CFGNode> lower(const std::string & in) {
     auto block = parse(in);
     const MIR::State::Persistant pstate{"foo/src", "foo/build", ""};
     auto ir = MIR::lower_ast(block, pstate);
@@ -27,11 +27,11 @@ std::shared_ptr<MIR::BasicBlock> lower(const std::string & in) {
 }
 
 inline bool is_bb(const MIR::NextType & next) {
-    return std::holds_alternative<std::shared_ptr<MIR::BasicBlock>>(next);
+    return std::holds_alternative<std::shared_ptr<MIR::CFGNode>>(next);
 }
 
-inline std::shared_ptr<MIR::BasicBlock> get_bb(const MIR::NextType & next) {
-    return std::get<std::shared_ptr<MIR::BasicBlock>>(next);
+inline std::shared_ptr<MIR::CFGNode> get_bb(const MIR::NextType & next) {
+    return std::get<std::shared_ptr<MIR::CFGNode>>(next);
 }
 
 inline bool is_con(const MIR::NextType & next) {

--- a/src/mir/ast_to_mir_test.cpp
+++ b/src/mir/ast_to_mir_test.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<Frontend::AST::CodeBlock> parse(const std::string & in) {
     return block;
 }
 
-MIR::BasicBlock lower(const std::string & in) {
+std::shared_ptr<MIR::BasicBlock> lower(const std::string & in) {
     auto block = parse(in);
     const MIR::State::Persistant pstate{"foo/src", "foo/build", ""};
     auto ir = MIR::lower_ast(block, pstate);
@@ -46,8 +46,8 @@ inline const std::unique_ptr<MIR::Condition> & get_con(const MIR::NextType & nex
 
 TEST(ast_to_ir, number) {
     auto irlist = lower("7");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::Number>(*obj.obj_ptr);
     ASSERT_EQ(ir.value, 7);
@@ -55,8 +55,8 @@ TEST(ast_to_ir, number) {
 
 TEST(ast_to_ir, boolean) {
     auto irlist = lower("true");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::Boolean>(*obj.obj_ptr);
     ASSERT_EQ(ir.value, true);
@@ -64,8 +64,8 @@ TEST(ast_to_ir, boolean) {
 
 TEST(ast_to_ir, string) {
     auto irlist = lower("'true'");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::String>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::String>(*obj.obj_ptr);
     ASSERT_EQ(ir.value, "true");
@@ -73,8 +73,8 @@ TEST(ast_to_ir, string) {
 
 TEST(ast_to_ir, array) {
     auto irlist = lower("['a', 'b', 1, [2]]");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Array>(*obj.obj_ptr));
 
     const auto & arr = std::get<MIR::Array>(*obj.obj_ptr);
@@ -95,8 +95,8 @@ TEST(ast_to_ir, array) {
 
 TEST(ast_to_ir, dict) {
     auto irlist = lower("{'str': 1}");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Dict>(*obj.obj_ptr));
 
     const auto & dict = std::get<MIR::Dict>(*obj.obj_ptr);
@@ -107,8 +107,8 @@ TEST(ast_to_ir, dict) {
 
 TEST(ast_to_ir, simple_function) {
     auto irlist = lower("has_no_args()");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -119,8 +119,8 @@ TEST(ast_to_ir, simple_function) {
 
 TEST(ast_to_ir, simple_method) {
     auto irlist = lower("obj.method()");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -134,8 +134,8 @@ TEST(ast_to_ir, simple_method) {
 
 TEST(ast_to_ir, chained_method) {
     auto irlist = lower("obj.method().chained()");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -165,8 +165,8 @@ TEST(ast_to_ir, method_in_function) {
 
 TEST(ast_to_ir, function_positional_arguments_only) {
     auto irlist = lower("has_args(1, 2, 3)");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -181,8 +181,8 @@ TEST(ast_to_ir, function_positional_arguments_only) {
 
 TEST(ast_to_ir, function_keyword_arguments_only) {
     auto irlist = lower("has_args(a : 1, b : '2')");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -203,8 +203,8 @@ TEST(ast_to_ir, function_keyword_arguments_only) {
 
 TEST(ast_to_ir, function_both_arguments) {
     auto irlist = lower("both_args(1, a, a : 1)");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -223,8 +223,8 @@ TEST(ast_to_ir, function_both_arguments) {
 
 TEST(ast_to_ir, if_only) {
     auto irlist = lower("if true\n 7\nendif\n");
-    ASSERT_TRUE(is_con(irlist.next));
-    auto const & con = get_con(irlist.next);
+    ASSERT_TRUE(is_con(irlist->next));
+    auto const & con = get_con(irlist->next);
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
     auto const & if_true = con->if_true->instructions;
@@ -242,8 +242,8 @@ TEST(ast_to_ir, if_branch_join) {
         endif
         8
         )EOF");
-    ASSERT_TRUE(is_con(irlist.next));
-    auto const & con = get_con(irlist.next);
+    ASSERT_TRUE(is_con(irlist->next));
+    auto const & con = get_con(irlist->next);
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
     auto const & if_true = con->if_true->instructions;
@@ -278,14 +278,14 @@ TEST(ast_to_ir, if_else_more) {
         y = x
         )EOF");
 
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    ASSERT_TRUE(is_con(irlist.next));
-    auto const & con = get_con(irlist.next);
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_TRUE(is_con(irlist->next));
+    auto const & con = get_con(irlist->next);
 
     ASSERT_EQ(con->if_true->instructions.size(), 1);
-    ASSERT_TRUE(con->if_true->predecessors.count(&irlist));
+    ASSERT_TRUE(con->if_true->predecessors.count(irlist.get()));
     ASSERT_EQ(con->if_false->instructions.size(), 1);
-    ASSERT_TRUE(con->if_false->predecessors.count(&irlist));
+    ASSERT_TRUE(con->if_false->predecessors.count(irlist.get()));
 
     ASSERT_TRUE(is_bb(con->if_true->next));
     ASSERT_EQ(get_bb(con->if_true->next), get_bb(con->if_false->next));
@@ -306,11 +306,11 @@ TEST(ast_to_ir, if_elif_else_more) {
         y = x     # 4
         )EOF");
     // block 0
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    ASSERT_TRUE(is_con(irlist.next));
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_TRUE(is_con(irlist->next));
 
     // block 1
-    auto const & con = get_con(irlist.next);
+    auto const & con = get_con(irlist->next);
     ASSERT_EQ(con->if_true->instructions.size(), 1);
     ASSERT_TRUE(is_bb(con->if_true->next));
 
@@ -328,8 +328,8 @@ TEST(ast_to_ir, if_elif_else_more) {
 
 TEST(ast_to_ir, if_else) {
     auto irlist = lower("if true\n 7\nelse\n8\nendif\n");
-    ASSERT_TRUE(is_con(irlist.next));
-    auto const & con = get_con(irlist.next);
+    ASSERT_TRUE(is_con(irlist->next));
+    auto const & con = get_con(irlist->next);
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
     auto const & if_true = con->if_true->instructions;
@@ -355,8 +355,8 @@ TEST(ast_to_ir, if_elif) {
           9
         endif
         )EOF");
-    ASSERT_TRUE(is_con(irlist.next));
-    auto const & con = get_con(irlist.next);
+    ASSERT_TRUE(is_con(irlist->next));
+    auto const & con = get_con(irlist->next);
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
     {
@@ -405,8 +405,8 @@ TEST(ast_to_ir, if_elif_else) {
     )EOF");
 
     // block 0
-    ASSERT_TRUE(is_con(irlist.next));
-    auto const & con = get_con(irlist.next);
+    ASSERT_TRUE(is_con(irlist->next));
+    auto const & con = get_con(irlist->next);
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
     // block 1
@@ -451,8 +451,8 @@ TEST(ast_to_ir, nested_if) {
         endif
         22
     )EOF");
-    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<MIR::Condition>>(irlist.next));
-    auto const & con = std::get<std::unique_ptr<MIR::Condition>>(irlist.next);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<MIR::Condition>>(irlist->next));
+    auto const & con = std::get<std::unique_ptr<MIR::Condition>>(irlist->next);
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
     {
@@ -506,9 +506,9 @@ TEST(ast_to_ir, nested_if_tail) {
         22               # 5
     )EOF");
 
-    ASSERT_TRUE(is_con(irlist.next));
+    ASSERT_TRUE(is_con(irlist->next));
 
-    const auto & con1 = get_con(irlist.next);
+    const auto & con1 = get_con(irlist->next);
     ASSERT_TRUE(is_con(con1->if_true->next));
 
     const auto & con2 = get_con(con1->if_true->next);
@@ -523,7 +523,7 @@ TEST(ast_to_ir, nested_if_tail) {
     ASSERT_EQ(con1->if_false, get_bb(con2->if_false->next));
     ASSERT_EQ(last_block->predecessors.size(), 2);
     ASSERT_TRUE(last_block->predecessors.count(con2->if_false.get()));
-    ASSERT_TRUE(last_block->predecessors.count(&irlist));
+    ASSERT_TRUE(last_block->predecessors.count(irlist.get()));
 }
 
 TEST(ast_to_ir, nested_if_no_tail) {
@@ -539,9 +539,9 @@ TEST(ast_to_ir, nested_if_no_tail) {
         # 5
     )EOF");
 
-    ASSERT_TRUE(is_con(irlist.next));
+    ASSERT_TRUE(is_con(irlist->next));
 
-    const auto & con1 = get_con(irlist.next);
+    const auto & con1 = get_con(irlist->next);
     ASSERT_TRUE(is_con(con1->if_true->next));
 
     const auto & con2 = get_con(con1->if_true->next);
@@ -556,7 +556,7 @@ TEST(ast_to_ir, nested_if_no_tail) {
     ASSERT_EQ(con1->if_false, get_bb(con2->if_false->next));
     ASSERT_EQ(last_block->predecessors.size(), 2);
     ASSERT_TRUE(last_block->predecessors.count(con2->if_false.get()));
-    ASSERT_TRUE(last_block->predecessors.count(&irlist));
+    ASSERT_TRUE(last_block->predecessors.count(irlist.get()));
 }
 
 TEST(ast_to_ir, nested_if_elif_tail) {
@@ -583,10 +583,10 @@ TEST(ast_to_ir, nested_if_elif_tail) {
         z = y      # 9
         )EOF");
 
-    const auto & fin = get_bb(get_con(irlist.next)->if_true->next);
+    const auto & fin = get_bb(get_con(irlist->next)->if_true->next);
 
     // block 2 (elif A)
-    const auto & con2 = get_con(irlist.next)->if_false;
+    const auto & con2 = get_con(irlist->next)->if_false;
     ASSERT_EQ(fin, get_bb(get_con(con2->next)->if_true->next));
 
     // block 3 (else)
@@ -603,8 +603,8 @@ TEST(ast_to_ir, nested_if_elif_tail) {
 
 TEST(ast_to_ir, assign) {
     auto irlist = lower("a = 5");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_EQ(obj.var.name, "a");
     ASSERT_EQ(obj.var.gvn, 0);
 
@@ -615,8 +615,8 @@ TEST(ast_to_ir, assign) {
 
 TEST(ast_to_ir, assign_from_id) {
     auto irlist = lower("a = b");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_EQ(obj.var.name, "a");
     ASSERT_EQ(obj.var.gvn, 0);
 
@@ -627,8 +627,8 @@ TEST(ast_to_ir, assign_from_id) {
 
 TEST(ast_to_ir, not_simple) {
     auto irlist = lower("not true");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
     ASSERT_EQ(ir.name, "unary_not");
@@ -637,8 +637,8 @@ TEST(ast_to_ir, not_simple) {
 
 TEST(ast_to_ir, not_method) {
     auto irlist = lower("not x.method()");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*ir.pos_args[0].obj_ptr));
@@ -646,8 +646,8 @@ TEST(ast_to_ir, not_method) {
 
 TEST(ast_to_ir, neg_simple) {
     auto irlist = lower("-5");
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & obj = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
     ASSERT_EQ(ir.name, "unary_neg");

--- a/src/mir/ast_to_mir_test.cpp
+++ b/src/mir/ast_to_mir_test.cpp
@@ -283,9 +283,9 @@ TEST(ast_to_ir, if_else_more) {
     auto const & con = get_con(irlist->next);
 
     ASSERT_EQ(con->if_true->instructions.size(), 1);
-    ASSERT_TRUE(con->if_true->predecessors.count(irlist.get()));
+    ASSERT_TRUE(con->if_true->predecessors.count(irlist));
     ASSERT_EQ(con->if_false->instructions.size(), 1);
-    ASSERT_TRUE(con->if_false->predecessors.count(irlist.get()));
+    ASSERT_TRUE(con->if_false->predecessors.count(irlist));
 
     ASSERT_TRUE(is_bb(con->if_true->next));
     ASSERT_EQ(get_bb(con->if_true->next), get_bb(con->if_false->next));
@@ -522,8 +522,8 @@ TEST(ast_to_ir, nested_if_tail) {
     // Block 4 and block 1 should both go to block 5
     ASSERT_EQ(con1->if_false, get_bb(con2->if_false->next));
     ASSERT_EQ(last_block->predecessors.size(), 2);
-    ASSERT_TRUE(last_block->predecessors.count(con2->if_false.get()));
-    ASSERT_TRUE(last_block->predecessors.count(irlist.get()));
+    ASSERT_TRUE(last_block->predecessors.count(con2->if_false));
+    ASSERT_TRUE(last_block->predecessors.count(irlist));
 }
 
 TEST(ast_to_ir, nested_if_no_tail) {
@@ -555,8 +555,8 @@ TEST(ast_to_ir, nested_if_no_tail) {
     // Block 4 and block 1 should both go to block 5
     ASSERT_EQ(con1->if_false, get_bb(con2->if_false->next));
     ASSERT_EQ(last_block->predecessors.size(), 2);
-    ASSERT_TRUE(last_block->predecessors.count(con2->if_false.get()));
-    ASSERT_TRUE(last_block->predecessors.count(irlist.get()));
+    ASSERT_TRUE(last_block->predecessors.count(con2->if_false));
+    ASSERT_TRUE(last_block->predecessors.count(irlist));
 }
 
 TEST(ast_to_ir, nested_if_elif_tail) {

--- a/src/mir/ast_to_mir_test.cpp
+++ b/src/mir/ast_to_mir_test.cpp
@@ -46,8 +46,8 @@ inline const std::unique_ptr<MIR::Condition> & get_con(const MIR::NextType & nex
 
 TEST(ast_to_ir, number) {
     auto irlist = lower("7");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::Number>(*obj.obj_ptr);
     ASSERT_EQ(ir.value, 7);
@@ -55,8 +55,8 @@ TEST(ast_to_ir, number) {
 
 TEST(ast_to_ir, boolean) {
     auto irlist = lower("true");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::Boolean>(*obj.obj_ptr);
     ASSERT_EQ(ir.value, true);
@@ -64,8 +64,8 @@ TEST(ast_to_ir, boolean) {
 
 TEST(ast_to_ir, string) {
     auto irlist = lower("'true'");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::String>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::String>(*obj.obj_ptr);
     ASSERT_EQ(ir.value, "true");
@@ -73,8 +73,8 @@ TEST(ast_to_ir, string) {
 
 TEST(ast_to_ir, array) {
     auto irlist = lower("['a', 'b', 1, [2]]");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Array>(*obj.obj_ptr));
 
     const auto & arr = std::get<MIR::Array>(*obj.obj_ptr);
@@ -95,8 +95,8 @@ TEST(ast_to_ir, array) {
 
 TEST(ast_to_ir, dict) {
     auto irlist = lower("{'str': 1}");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Dict>(*obj.obj_ptr));
 
     const auto & dict = std::get<MIR::Dict>(*obj.obj_ptr);
@@ -107,8 +107,8 @@ TEST(ast_to_ir, dict) {
 
 TEST(ast_to_ir, simple_function) {
     auto irlist = lower("has_no_args()");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -119,8 +119,8 @@ TEST(ast_to_ir, simple_function) {
 
 TEST(ast_to_ir, simple_method) {
     auto irlist = lower("obj.method()");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -134,8 +134,8 @@ TEST(ast_to_ir, simple_method) {
 
 TEST(ast_to_ir, chained_method) {
     auto irlist = lower("obj.method().chained()");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -165,8 +165,8 @@ TEST(ast_to_ir, method_in_function) {
 
 TEST(ast_to_ir, function_positional_arguments_only) {
     auto irlist = lower("has_args(1, 2, 3)");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -181,8 +181,8 @@ TEST(ast_to_ir, function_positional_arguments_only) {
 
 TEST(ast_to_ir, function_keyword_arguments_only) {
     auto irlist = lower("has_args(a : 1, b : '2')");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -203,8 +203,8 @@ TEST(ast_to_ir, function_keyword_arguments_only) {
 
 TEST(ast_to_ir, function_both_arguments) {
     auto irlist = lower("both_args(1, a, a : 1)");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
 
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
@@ -227,7 +227,7 @@ TEST(ast_to_ir, if_only) {
     auto const & con = get_con(irlist->next);
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
-    auto const & if_true = con->if_true->instructions;
+    auto const & if_true = con->if_true->block->instructions;
     ASSERT_EQ(if_true.size(), 1);
 
     auto const & val = if_true.front();
@@ -246,7 +246,7 @@ TEST(ast_to_ir, if_branch_join) {
     auto const & con = get_con(irlist->next);
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
-    auto const & if_true = con->if_true->instructions;
+    auto const & if_true = con->if_true->block->instructions;
     ASSERT_EQ(if_true.size(), 1);
 
     auto const & val = if_true.front();
@@ -257,7 +257,7 @@ TEST(ast_to_ir, if_branch_join) {
 
     auto const & block2 = con->if_false;
     ASSERT_NE(block2, nullptr);
-    auto const & val2 = block2->instructions.front();
+    auto const & val2 = block2->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val2.obj_ptr));
     ASSERT_EQ(std::get<MIR::Number>(*val2.obj_ptr).value, 8);
 
@@ -278,19 +278,19 @@ TEST(ast_to_ir, if_else_more) {
         y = x
         )EOF");
 
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
     ASSERT_TRUE(is_con(irlist->next));
     auto const & con = get_con(irlist->next);
 
-    ASSERT_EQ(con->if_true->instructions.size(), 1);
+    ASSERT_EQ(con->if_true->block->instructions.size(), 1);
     ASSERT_TRUE(con->if_true->predecessors.count(irlist));
-    ASSERT_EQ(con->if_false->instructions.size(), 1);
+    ASSERT_EQ(con->if_false->block->instructions.size(), 1);
     ASSERT_TRUE(con->if_false->predecessors.count(irlist));
 
     ASSERT_TRUE(is_bb(con->if_true->next));
     ASSERT_EQ(get_bb(con->if_true->next), get_bb(con->if_false->next));
 
-    ASSERT_EQ(get_bb(con->if_true->next)->instructions.size(), 1);
+    ASSERT_EQ(get_bb(con->if_true->next)->block->instructions.size(), 1);
 }
 
 TEST(ast_to_ir, if_elif_else_more) {
@@ -306,23 +306,23 @@ TEST(ast_to_ir, if_elif_else_more) {
         y = x     # 4
         )EOF");
     // block 0
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
     ASSERT_TRUE(is_con(irlist->next));
 
     // block 1
     auto const & con = get_con(irlist->next);
-    ASSERT_EQ(con->if_true->instructions.size(), 1);
+    ASSERT_EQ(con->if_true->block->instructions.size(), 1);
     ASSERT_TRUE(is_bb(con->if_true->next));
 
     // block 2
     ASSERT_TRUE(is_con(con->if_false->next));
     auto const & con1 = get_con(con->if_false->next);
-    ASSERT_EQ(con1->if_true->instructions.size(), 1);
+    ASSERT_EQ(con1->if_true->block->instructions.size(), 1);
     ASSERT_TRUE(is_bb(con1->if_true->next));
 
     // block 3
     auto const & else_block = con1->if_false;
-    ASSERT_EQ(else_block->instructions.size(), 1);
+    ASSERT_EQ(else_block->block->instructions.size(), 1);
     ASSERT_TRUE(is_bb(else_block->next));
 }
 
@@ -332,13 +332,13 @@ TEST(ast_to_ir, if_else) {
     auto const & con = get_con(irlist->next);
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
-    auto const & if_true = con->if_true->instructions;
+    auto const & if_true = con->if_true->block->instructions;
     ASSERT_EQ(if_true.size(), 1);
     auto const & val = if_true.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val.obj_ptr));
     ASSERT_EQ(std::get<MIR::Number>(*val.obj_ptr).value, 7);
 
-    auto const & if_false = con->if_false->instructions;
+    auto const & if_false = con->if_false->block->instructions;
     ASSERT_EQ(if_false.size(), 1);
     auto const & val2 = if_false.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val2.obj_ptr));
@@ -360,7 +360,7 @@ TEST(ast_to_ir, if_elif) {
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
     {
-        auto const & if_true = con->if_true->instructions;
+        auto const & if_true = con->if_true->block->instructions;
         ASSERT_EQ(if_true.size(), 1);
         auto const & val = if_true.front();
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val.obj_ptr));
@@ -372,7 +372,7 @@ TEST(ast_to_ir, if_elif) {
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*elcon->condition.obj_ptr));
 
     {
-        auto const & if_true = elcon->if_true->instructions;
+        auto const & if_true = elcon->if_true->block->instructions;
         ASSERT_EQ(if_true.size(), 1);
         auto const & val = if_true.front();
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val.obj_ptr));
@@ -383,7 +383,7 @@ TEST(ast_to_ir, if_elif) {
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*elcon2->condition.obj_ptr));
 
     {
-        auto const & if_true = elcon2->if_true->instructions;
+        auto const & if_true = elcon2->if_true->block->instructions;
         ASSERT_EQ(if_true.size(), 1);
         auto const & val = if_true.front();
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val.obj_ptr));
@@ -411,7 +411,7 @@ TEST(ast_to_ir, if_elif_else) {
 
     // block 1
     {
-        auto const & if_true = con->if_true->instructions;
+        auto const & if_true = con->if_true->block->instructions;
         ASSERT_EQ(if_true.size(), 1);
         auto const & val = if_true.front();
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val.obj_ptr));
@@ -423,14 +423,14 @@ TEST(ast_to_ir, if_elif_else) {
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*elcon->condition.obj_ptr));
 
     // /block 2
-    auto const & if_true = elcon->if_true->instructions;
+    auto const & if_true = elcon->if_true->block->instructions;
     ASSERT_EQ(if_true.size(), 1);
     auto const & val = if_true.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val.obj_ptr));
     ASSERT_EQ(std::get<MIR::Number>(*val.obj_ptr).value, 8);
 
     // blcok 3
-    auto const & if_false = elcon->if_false->instructions;
+    auto const & if_false = elcon->if_false->block->instructions;
     ASSERT_EQ(if_false.size(), 1);
     auto const & val2 = if_false.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val2.obj_ptr));
@@ -456,20 +456,20 @@ TEST(ast_to_ir, nested_if) {
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*con->condition.obj_ptr));
 
     {
-        auto const & if_true = con->if_true->instructions;
+        auto const & if_true = con->if_true->block->instructions;
         ASSERT_EQ(if_true.size(), 1);
         auto const & val = if_true.front();
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val.obj_ptr));
         ASSERT_EQ(std::get<MIR::Number>(*val.obj_ptr).value, 7);
 
         auto const & con2 = get_con(con->if_true->next);
-        auto const & val2 = con2->if_true->instructions.front();
+        auto const & val2 = con2->if_true->block->instructions.front();
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val2.obj_ptr));
         ASSERT_EQ(std::get<MIR::Number>(*val2.obj_ptr).value, 10);
 
         const auto & fin = get_bb(get_bb(con2->if_true->next)->next);
-        ASSERT_EQ(fin->instructions.size(), 1);
-        auto const & val3 = fin->instructions.front();
+        ASSERT_EQ(fin->block->instructions.size(), 1);
+        auto const & val3 = fin->block->instructions.front();
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val3.obj_ptr));
         ASSERT_EQ(std::get<MIR::Number>(*val3.obj_ptr).value, 22);
     }
@@ -479,13 +479,13 @@ TEST(ast_to_ir, nested_if) {
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*elcon->condition.obj_ptr));
 
     {
-        auto const & if_true = elcon->if_true->instructions;
+        auto const & if_true = elcon->if_true->block->instructions;
         ASSERT_EQ(if_true.size(), 1);
         auto const & val = if_true.front();
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val.obj_ptr));
         ASSERT_EQ(std::get<MIR::Number>(*val.obj_ptr).value, 8);
 
-        auto const & if_false = elcon->if_false->instructions;
+        auto const & if_false = elcon->if_false->block->instructions;
         ASSERT_EQ(if_false.size(), 1);
         auto const & val2 = if_false.front();
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*val2.obj_ptr));
@@ -603,8 +603,8 @@ TEST(ast_to_ir, nested_if_elif_tail) {
 
 TEST(ast_to_ir, assign) {
     auto irlist = lower("a = 5");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_EQ(obj.var.name, "a");
     ASSERT_EQ(obj.var.gvn, 0);
 
@@ -615,8 +615,8 @@ TEST(ast_to_ir, assign) {
 
 TEST(ast_to_ir, assign_from_id) {
     auto irlist = lower("a = b");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_EQ(obj.var.name, "a");
     ASSERT_EQ(obj.var.gvn, 0);
 
@@ -627,8 +627,8 @@ TEST(ast_to_ir, assign_from_id) {
 
 TEST(ast_to_ir, not_simple) {
     auto irlist = lower("not true");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
     ASSERT_EQ(ir.name, "unary_not");
@@ -637,8 +637,8 @@ TEST(ast_to_ir, not_simple) {
 
 TEST(ast_to_ir, not_method) {
     auto irlist = lower("not x.method()");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*ir.pos_args[0].obj_ptr));
@@ -646,8 +646,8 @@ TEST(ast_to_ir, not_method) {
 
 TEST(ast_to_ir, neg_simple) {
     auto irlist = lower("-5");
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & obj = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*obj.obj_ptr));
     const auto & ir = std::get<MIR::FunctionCall>(*obj.obj_ptr);
     ASSERT_EQ(ir.name, "unary_neg");

--- a/src/mir/ast_to_mir_test.cpp
+++ b/src/mir/ast_to_mir_test.cpp
@@ -283,9 +283,9 @@ TEST(ast_to_ir, if_else_more) {
     auto const & con = get_con(irlist.next);
 
     ASSERT_EQ(con->if_true->instructions.size(), 1);
-    ASSERT_TRUE(con->if_true->parents.count(&irlist));
+    ASSERT_TRUE(con->if_true->predecessors.count(&irlist));
     ASSERT_EQ(con->if_false->instructions.size(), 1);
-    ASSERT_TRUE(con->if_false->parents.count(&irlist));
+    ASSERT_TRUE(con->if_false->predecessors.count(&irlist));
 
     ASSERT_TRUE(is_bb(con->if_true->next));
     ASSERT_EQ(get_bb(con->if_true->next), get_bb(con->if_false->next));
@@ -521,9 +521,9 @@ TEST(ast_to_ir, nested_if_tail) {
 
     // Block 4 and block 1 should both go to block 5
     ASSERT_EQ(con1->if_false, get_bb(con2->if_false->next));
-    ASSERT_EQ(last_block->parents.size(), 2);
-    ASSERT_TRUE(last_block->parents.count(con2->if_false.get()));
-    ASSERT_TRUE(last_block->parents.count(&irlist));
+    ASSERT_EQ(last_block->predecessors.size(), 2);
+    ASSERT_TRUE(last_block->predecessors.count(con2->if_false.get()));
+    ASSERT_TRUE(last_block->predecessors.count(&irlist));
 }
 
 TEST(ast_to_ir, nested_if_no_tail) {
@@ -554,9 +554,9 @@ TEST(ast_to_ir, nested_if_no_tail) {
 
     // Block 4 and block 1 should both go to block 5
     ASSERT_EQ(con1->if_false, get_bb(con2->if_false->next));
-    ASSERT_EQ(last_block->parents.size(), 2);
-    ASSERT_TRUE(last_block->parents.count(con2->if_false.get()));
-    ASSERT_TRUE(last_block->parents.count(&irlist));
+    ASSERT_EQ(last_block->predecessors.size(), 2);
+    ASSERT_TRUE(last_block->predecessors.count(con2->if_false.get()));
+    ASSERT_TRUE(last_block->predecessors.count(&irlist));
 }
 
 TEST(ast_to_ir, nested_if_elif_tail) {

--- a/src/mir/lower.cpp
+++ b/src/mir/lower.cpp
@@ -18,7 +18,7 @@ namespace {
 // TODO: compilers may need to be run again if `add_language` is called
 void early(std::shared_ptr<MIR::CFGNode> block, State::Persistant & pstate,
            Passes::Printer & printer) {
-    Passes::block_walker(block, {
+    Passes::graph_walker(block, {
                                     [&](std::shared_ptr<CFGNode> b) {
                                         return Passes::machine_lower(b, pstate.machines) ||
                                                Passes::insert_compilers(b, pstate.toolchains);
@@ -49,7 +49,7 @@ void main(std::shared_ptr<MIR::CFGNode> block, State::Persistant & pstate,
     bool progress = false;
     do {
         printer.increment();
-        progress = Passes::block_walker(block, std::ref(main_loop));
+        progress = Passes::graph_walker(block, std::ref(main_loop));
     } while (progress);
 
     // Run the main lowering loop until it cannot lower any more, then do the
@@ -59,7 +59,7 @@ void main(std::shared_ptr<MIR::CFGNode> block, State::Persistant & pstate,
     if (Passes::threaded_lowering(block, pstate)) {
         do {
             printer.increment();
-            progress = Passes::block_walker(block, std::ref(main_loop));
+            progress = Passes::graph_walker(block, std::ref(main_loop));
         } while (progress);
     }
 }
@@ -72,7 +72,7 @@ void late(std::shared_ptr<MIR::CFGNode> block, State::Persistant & pstate,
     };
 
     printer.increment();
-    Passes::block_walker(block, std::ref(loop));
+    Passes::graph_walker(block, std::ref(loop));
 }
 
 } // namespace

--- a/src/mir/lower.cpp
+++ b/src/mir/lower.cpp
@@ -20,8 +20,10 @@ void early(std::shared_ptr<MIR::CFGNode> block, State::Persistant & pstate,
            Passes::Printer & printer) {
     Passes::graph_walker(block, {
                                     [&](std::shared_ptr<CFGNode> b) {
-                                        return Passes::machine_lower(b, pstate.machines) ||
-                                               Passes::insert_compilers(b, pstate.toolchains);
+                                        return Passes::machine_lower(b, pstate.machines);
+                                    },
+                                    [&](std::shared_ptr<CFGNode> b) {
+                                        return Passes::insert_compilers(b, pstate.toolchains);
                                     },
                                     Passes::custom_target_program_replacement,
                                     Passes::GlobalValueNumbering{},

--- a/src/mir/lower.hpp
+++ b/src/mir/lower.hpp
@@ -13,7 +13,7 @@
 
 namespace MIR {
 
-void lower(BasicBlock &, State::Persistant &);
+void lower(std::shared_ptr<BasicBlock>, State::Persistant &);
 
 namespace Passes {
 
@@ -24,7 +24,7 @@ namespace Passes {
  * meson.build file. later on, when we handle project() it will simply be an
  * error to have it, so right now we wnat to read it, and delete it.
  */
-void lower_project(BasicBlock & block, State::Persistant & pstate);
+void lower_project(std::shared_ptr<BasicBlock> block, State::Persistant & pstate);
 
 } // namespace Passes
 

--- a/src/mir/lower.hpp
+++ b/src/mir/lower.hpp
@@ -13,7 +13,7 @@
 
 namespace MIR {
 
-void lower(std::shared_ptr<BasicBlock>, State::Persistant &);
+void lower(std::shared_ptr<CFGNode>, State::Persistant &);
 
 namespace Passes {
 
@@ -24,7 +24,7 @@ namespace Passes {
  * meson.build file. later on, when we handle project() it will simply be an
  * error to have it, so right now we wnat to read it, and delete it.
  */
-void lower_project(std::shared_ptr<BasicBlock> block, State::Persistant & pstate);
+void lower_project(std::shared_ptr<CFGNode> block, State::Persistant & pstate);
 
 } // namespace Passes
 

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -96,6 +96,7 @@ Instruction::Instruction(Program val) : obj_ptr{std::make_shared<Object>(std::mo
 Instruction::Instruction(Test val) : obj_ptr{std::make_shared<Object>(std::move(val))} {};
 Instruction::Instruction(AddArguments val) : obj_ptr{std::make_shared<Object>(std::move(val))} {};
 Instruction::Instruction(Jump val) : obj_ptr{std::make_shared<Object>(std::move(val))} {};
+Instruction::Instruction(Branch val) : obj_ptr{std::make_shared<Object>(std::move(val))} {};
 
 std::string Instruction::print() const {
     const std::string i = std::visit(
@@ -415,6 +416,18 @@ Jump::Jump(std::shared_ptr<CFGNode> t, std::shared_ptr<Instruction> p)
 std::string Jump::print() const {
     return "jump = { target = { " + std::to_string(target->index) + " }, predicate = { " +
            (predicate == nullptr ? "always" : predicate->print()) + " } }";
+}
+
+Branch::Branch() = default;
+
+std::string Branch::print() const {
+    std::stringstream ss;
+    ss << "branch = { ";
+    for (auto && [i, dest] : branches) {
+        ss << "branch " << i.print() << " = { " << dest->index << " }, ";
+    }
+    ss << " }" << std::endl;
+    return ss.str();
 }
 
 void link_nodes(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor) {

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -137,8 +137,9 @@ BasicBlock::BasicBlock(std::unique_ptr<Condition> && con)
 
 bool BasicBlock::operator<(const BasicBlock & other) const { return index < other.index; }
 
-bool BBComparitor::operator()(const BasicBlock * lhs, const BasicBlock * rhs) const {
-    return *lhs < *rhs;
+bool BBComparitor::operator()(const std::weak_ptr<BasicBlock> lhs,
+                              const std::weak_ptr<BasicBlock> rhs) const {
+    return *lhs.lock() < *rhs.lock();
 }
 
 bool BBComparitor::operator()(const std::shared_ptr<BasicBlock> & lhs,

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -95,6 +95,7 @@ Instruction::Instruction(Phi val) : obj_ptr{std::make_shared<Object>(val)} {};
 Instruction::Instruction(Program val) : obj_ptr{std::make_shared<Object>(std::move(val))} {};
 Instruction::Instruction(Test val) : obj_ptr{std::make_shared<Object>(std::move(val))} {};
 Instruction::Instruction(AddArguments val) : obj_ptr{std::make_shared<Object>(std::move(val))} {};
+Instruction::Instruction(Jump val) : obj_ptr{std::make_shared<Object>(std::move(val))} {};
 
 std::string Instruction::print() const {
     const std::string i = std::visit(
@@ -405,6 +406,15 @@ std::string AddArguments::print() const {
     ss << " is_global = { " << is_global << " } }";
 
     return ss.str();
+}
+
+Jump::Jump(std::shared_ptr<CFGNode> t) : target{std::move(t)} {};
+Jump::Jump(std::shared_ptr<CFGNode> t, std::shared_ptr<Instruction> p)
+    : target{std::move(t)}, predicate{std::move(p)} {};
+
+std::string Jump::print() const {
+    return "jump = { target = { " + std::to_string(target->index) + " }, predicate = { " +
+           (predicate == nullptr ? "always" : predicate->print()) + " } }";
 }
 
 } // namespace MIR

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -141,6 +141,11 @@ bool BBComparitor::operator()(const BasicBlock * lhs, const BasicBlock * rhs) co
     return *lhs < *rhs;
 }
 
+bool BBComparitor::operator()(const std::shared_ptr<BasicBlock> & lhs,
+                              const std::shared_ptr<BasicBlock> & rhs) const {
+    return *lhs < *rhs;
+}
+
 Condition::Condition(Instruction && o)
     : condition{std::move(o)}, if_true{std::make_shared<BasicBlock>()}, if_false{nullptr} {};
 

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -130,27 +130,26 @@ std::string Phi::print() const {
     return "Phi { left = " + to_string(left) + "; right = " + to_string(right) + " }";
 }
 
-BasicBlock::BasicBlock() : next{std::monostate{}}, index{++bb_index} {};
+CFGNode::CFGNode() : next{std::monostate{}}, index{++bb_index} {};
 
-BasicBlock::BasicBlock(std::unique_ptr<Condition> && con)
-    : next{std::move(con)}, index{++bb_index} {};
+CFGNode::CFGNode(std::unique_ptr<Condition> && con) : next{std::move(con)}, index{++bb_index} {};
 
-bool BasicBlock::operator<(const BasicBlock & other) const { return index < other.index; }
+bool CFGNode::operator<(const CFGNode & other) const { return index < other.index; }
 
-bool BBComparitor::operator()(const std::weak_ptr<BasicBlock> lhs,
-                              const std::weak_ptr<BasicBlock> rhs) const {
+bool CFGComparitor::operator()(const std::weak_ptr<CFGNode> lhs,
+                               const std::weak_ptr<CFGNode> rhs) const {
     return *lhs.lock() < *rhs.lock();
 }
 
-bool BBComparitor::operator()(const std::shared_ptr<BasicBlock> & lhs,
-                              const std::shared_ptr<BasicBlock> & rhs) const {
+bool CFGComparitor::operator()(const std::shared_ptr<CFGNode> & lhs,
+                               const std::shared_ptr<CFGNode> & rhs) const {
     return *lhs < *rhs;
 }
 
 Condition::Condition(Instruction && o)
-    : condition{std::move(o)}, if_true{std::make_shared<BasicBlock>()}, if_false{nullptr} {};
+    : condition{std::move(o)}, if_true{std::make_shared<CFGNode>()}, if_false{nullptr} {};
 
-Condition::Condition(Instruction && o, std::shared_ptr<BasicBlock> s)
+Condition::Condition(Instruction && o, std::shared_ptr<CFGNode> s)
     : condition{std::move(o)}, if_true{std::move(s)}, if_false{nullptr} {};
 
 Compiler::Compiler(std::shared_ptr<MIR::Toolchain::Toolchain> tc) : toolchain{std::move(tc)} {};

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -132,11 +132,7 @@ std::string Phi::print() const {
     return "Phi { left = " + to_string(left) + "; right = " + to_string(right) + " }";
 }
 
-CFGNode::CFGNode()
-    : block{std::make_unique<BasicBlock>()}, next{std::monostate{}}, index{++bb_index} {};
-
-CFGNode::CFGNode(std::unique_ptr<Condition> && con)
-    : block{std::make_unique<BasicBlock>()}, next{std::move(con)}, index{++bb_index} {};
+CFGNode::CFGNode() : block{std::make_unique<BasicBlock>()}, index{++bb_index} {};
 
 bool CFGNode::operator<(const CFGNode & other) const { return index < other.index; }
 
@@ -151,12 +147,6 @@ bool CFGComparitor::operator()(const std::shared_ptr<CFGNode> & lhs,
 }
 
 CFG::CFG(std::shared_ptr<CFGNode> n) : root{n} {};
-
-Condition::Condition(Instruction && o)
-    : condition{std::move(o)}, if_true{std::make_shared<CFGNode>()}, if_false{nullptr} {};
-
-Condition::Condition(Instruction && o, std::shared_ptr<CFGNode> s)
-    : condition{std::move(o)}, if_true{std::move(s)}, if_false{nullptr} {};
 
 Compiler::Compiler(std::shared_ptr<MIR::Toolchain::Toolchain> tc) : toolchain{std::move(tc)} {};
 
@@ -414,7 +404,7 @@ Jump::Jump(std::shared_ptr<CFGNode> t, std::shared_ptr<Instruction> p)
     : target{std::move(t)}, predicate{std::move(p)} {};
 
 std::string Jump::print() const {
-    return "jump = { target = { " + std::to_string(target->index) + " }, predicate = { " +
+    return "jump { target = { " + std::to_string(target->index) + " }; predicate = { " +
            (predicate == nullptr ? "always" : predicate->print()) + " } }";
 }
 
@@ -426,7 +416,7 @@ std::string Branch::print() const {
     for (auto && [i, dest] : branches) {
         ss << "branch " << i.print() << " = { " << dest->index << " }, ";
     }
-    ss << " }" << std::endl;
+    ss << " }";
     return ss.str();
 }
 

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -130,9 +130,11 @@ std::string Phi::print() const {
     return "Phi { left = " + to_string(left) + "; right = " + to_string(right) + " }";
 }
 
-CFGNode::CFGNode() : next{std::monostate{}}, index{++bb_index} {};
+CFGNode::CFGNode()
+    : block{std::make_unique<BasicBlock>()}, next{std::monostate{}}, index{++bb_index} {};
 
-CFGNode::CFGNode(std::unique_ptr<Condition> && con) : next{std::move(con)}, index{++bb_index} {};
+CFGNode::CFGNode(std::unique_ptr<Condition> && con)
+    : block{std::make_unique<BasicBlock>()}, next{std::move(con)}, index{++bb_index} {};
 
 bool CFGNode::operator<(const CFGNode & other) const { return index < other.index; }
 

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -146,6 +146,8 @@ bool CFGComparitor::operator()(const std::shared_ptr<CFGNode> & lhs,
     return *lhs < *rhs;
 }
 
+CFG::CFG(std::shared_ptr<CFGNode> n) : root{n} {};
+
 Condition::Condition(Instruction && o)
     : condition{std::move(o)}, if_true{std::make_shared<CFGNode>()}, if_false{nullptr} {};
 

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -417,4 +417,14 @@ std::string Jump::print() const {
            (predicate == nullptr ? "always" : predicate->print()) + " } }";
 }
 
+void link_blocks(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor) {
+    successor->predecessors.emplace(predecessor);
+    predecessor->successors.emplace(successor);
+}
+
+void unlink_blocks(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor) {
+    successor->predecessors.erase(predecessor);
+    predecessor->successors.erase(successor);
+}
+
 } // namespace MIR

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -79,11 +79,12 @@ class Empty;
 class CustomTarget;
 class Dependency;
 class Test;
+class Jump;
 
 using Object =
     std::variant<std::monostate, FunctionCall, String, Boolean, Number, Identifier, Array, Dict,
                  Compiler, File, Executable, StaticLibrary, Phi, IncludeDirectories, Message,
-                 Program, Empty, CustomTarget, Dependency, Test, AddArguments>;
+                 Program, Empty, CustomTarget, Dependency, Test, AddArguments, Jump>;
 
 using Callable = std::variant<File, Executable, Program>;
 
@@ -118,6 +119,7 @@ class Instruction {
     Instruction(Program val);
     Instruction(Test val);
     Instruction(AddArguments val);
+    Instruction(Jump val);
 
     Instruction & operator=(const Instruction &) = default;
 
@@ -544,6 +546,24 @@ class AddArguments {
 };
 
 class CFGNode;
+
+/// @brief Jump to another block
+class Jump {
+  public:
+    Jump(std::shared_ptr<CFGNode> t);
+    Jump(std::shared_ptr<CFGNode> t, std::shared_ptr<Instruction> p);
+
+    /// @brief Print a human readable version of this instruction
+    /// @return A string representing the instructions
+    std::string print() const;
+
+    /// @brief The block to jump to
+    std::shared_ptr<CFGNode> target;
+
+    /// @brief A potential predicate of the jump
+    /// If this is a nullptr it is considered unconditional
+    std::shared_ptr<Instruction> predicate;
+};
 
 /**
  * A think that creates A conditional web.

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -588,6 +588,14 @@ using NextType = std::variant<std::monostate, std::unique_ptr<Condition>, std::s
 
 class CFGNode;
 
+class BasicBlock {
+  public:
+    BasicBlock() = default;
+
+    /// The instructions in this block
+    std::list<Instruction> instructions;
+};
+
 struct CFGComparitor {
     bool operator()(const std::weak_ptr<CFGNode> lhs, const std::weak_ptr<CFGNode> rhs) const;
     bool operator()(const std::shared_ptr<CFGNode> & lhs,
@@ -602,8 +610,8 @@ class CFGNode {
     CFGNode();
     CFGNode(std::unique_ptr<Condition> &&);
 
-    /// The instructions in this block
-    std::list<Instruction> instructions;
+    /// @brief The block instructions
+    std::unique_ptr<BasicBlock> block;
 
     /// Either nothing, a pointer to another CFGNode, or a pointer to a Condition
     NextType next;

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -543,7 +543,7 @@ class AddArguments {
     bool is_global;
 };
 
-class BasicBlock;
+class CFGNode;
 
 /**
  * A think that creates A conditional web.
@@ -569,55 +569,54 @@ class BasicBlock;
 class Condition {
   public:
     Condition(Instruction && o);
-    Condition(Instruction && o, std::shared_ptr<BasicBlock> s);
+    Condition(Instruction && o, std::shared_ptr<CFGNode> s);
 
     /// An object that is the condition
     Instruction condition;
 
     /// The block to go to if the condition is true
-    std::shared_ptr<BasicBlock> if_true;
+    std::shared_ptr<CFGNode> if_true;
 
     /// The block to go to if the condition is false
-    std::shared_ptr<BasicBlock> if_false;
+    std::shared_ptr<CFGNode> if_false;
 
     /// Print a human readable version of this
     std::string print() const;
 };
 
-using NextType =
-    std::variant<std::monostate, std::unique_ptr<Condition>, std::shared_ptr<BasicBlock>>;
+using NextType = std::variant<std::monostate, std::unique_ptr<Condition>, std::shared_ptr<CFGNode>>;
 
-class BasicBlock;
+class CFGNode;
 
-struct BBComparitor {
-    bool operator()(const std::weak_ptr<BasicBlock> lhs, const std::weak_ptr<BasicBlock> rhs) const;
-    bool operator()(const std::shared_ptr<BasicBlock> & lhs,
-                    const std::shared_ptr<BasicBlock> & rhs) const;
+struct CFGComparitor {
+    bool operator()(const std::weak_ptr<CFGNode> lhs, const std::weak_ptr<CFGNode> rhs) const;
+    bool operator()(const std::shared_ptr<CFGNode> & lhs,
+                    const std::shared_ptr<CFGNode> & rhs) const;
 };
 
 /**
  * Holds a list of instructions, and optionally a condition or next block
  */
-class BasicBlock {
+class CFGNode {
   public:
-    BasicBlock();
-    BasicBlock(std::unique_ptr<Condition> &&);
+    CFGNode();
+    CFGNode(std::unique_ptr<Condition> &&);
 
     /// The instructions in this block
     std::list<Instruction> instructions;
 
-    /// Either nothing, a pointer to another BasicBlock, or a pointer to a Condition
+    /// Either nothing, a pointer to another CFGNode, or a pointer to a Condition
     NextType next;
 
     /// All predecessors of this block
-    std::set<std::weak_ptr<BasicBlock>, BBComparitor> predecessors;
+    std::set<std::weak_ptr<CFGNode>, CFGComparitor> predecessors;
 
     /// @brief All blocks that come after this one
-    std::set<std::shared_ptr<BasicBlock>, BBComparitor> successors;
+    std::set<std::shared_ptr<CFGNode>, CFGComparitor> successors;
 
     const uint32_t index;
 
-    bool operator<(const BasicBlock &) const;
+    bool operator<(const CFGNode &) const;
 
     /// Print a human readable version of this
     std::string print() const;

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -617,9 +617,6 @@ class CFGNode {
     const uint32_t index;
 
     bool operator<(const CFGNode &) const;
-
-    /// Print a human readable version of this
-    std::string print() const;
 };
 
 class CFG {

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -654,4 +654,7 @@ class CFG {
     std::shared_ptr<CFGNode> root;
 };
 
+void link_blocks(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor);
+void unlink_blocks(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor);
+
 } // namespace MIR

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -654,7 +654,7 @@ class CFG {
     std::shared_ptr<CFGNode> root;
 };
 
-void link_blocks(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor);
-void unlink_blocks(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor);
+void link_nodes(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor);
+void unlink_nodes(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor);
 
 } // namespace MIR

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -80,11 +80,12 @@ class CustomTarget;
 class Dependency;
 class Test;
 class Jump;
+class Branch;
 
 using Object =
     std::variant<std::monostate, FunctionCall, String, Boolean, Number, Identifier, Array, Dict,
                  Compiler, File, Executable, StaticLibrary, Phi, IncludeDirectories, Message,
-                 Program, Empty, CustomTarget, Dependency, Test, AddArguments, Jump>;
+                 Program, Empty, CustomTarget, Dependency, Test, AddArguments, Jump, Branch>;
 
 using Callable = std::variant<File, Executable, Program>;
 
@@ -120,6 +121,7 @@ class Instruction {
     Instruction(Test val);
     Instruction(AddArguments val);
     Instruction(Jump val);
+    Instruction(Branch val);
 
     Instruction & operator=(const Instruction &) = default;
 
@@ -563,6 +565,19 @@ class Jump {
     /// @brief A potential predicate of the jump
     /// If this is a nullptr it is considered unconditional
     std::shared_ptr<Instruction> predicate;
+};
+
+/// @brief An instruction for jumping to multiple targets based on conditions
+///
+/// This is mainly used as a high level if/elif/else construction,
+/// but we expect to later lower it to Jumps
+class Branch {
+  public:
+    Branch();
+
+    std::vector<std::tuple<Instruction, std::shared_ptr<CFGNode>>> branches;
+
+    std::string print() const;
 };
 
 /**

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -590,7 +590,7 @@ using NextType =
 class BasicBlock;
 
 struct BBComparitor {
-    bool operator()(const BasicBlock * lhs, const BasicBlock * rhs) const;
+    bool operator()(const std::weak_ptr<BasicBlock> lhs, const std::weak_ptr<BasicBlock> rhs) const;
     bool operator()(const std::shared_ptr<BasicBlock> & lhs,
                     const std::shared_ptr<BasicBlock> & rhs) const;
 };
@@ -610,7 +610,7 @@ class BasicBlock {
     NextType next;
 
     /// All predecessors of this block
-    std::set<BasicBlock *, BBComparitor> predecessors;
+    std::set<std::weak_ptr<BasicBlock>, BBComparitor> predecessors;
 
     /// @brief All blocks that come after this one
     std::set<std::shared_ptr<BasicBlock>, BBComparitor> successors;

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -622,4 +622,11 @@ class CFGNode {
     std::string print() const;
 };
 
+class CFG {
+  public:
+    CFG(std::shared_ptr<CFGNode> n);
+
+    std::shared_ptr<CFGNode> root;
+};
+
 } // namespace MIR

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -607,8 +607,8 @@ class BasicBlock {
     /// Either nothing, a pointer to another BasicBlock, or a pointer to a Condition
     NextType next;
 
-    /// All potential parents of this block
-    std::set<BasicBlock *, BBComparitor> parents;
+    /// All predecessors of this block
+    std::set<BasicBlock *, BBComparitor> predecessors;
 
     const uint32_t index;
 

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -591,6 +591,8 @@ class BasicBlock;
 
 struct BBComparitor {
     bool operator()(const BasicBlock * lhs, const BasicBlock * rhs) const;
+    bool operator()(const std::shared_ptr<BasicBlock> & lhs,
+                    const std::shared_ptr<BasicBlock> & rhs) const;
 };
 
 /**
@@ -609,6 +611,9 @@ class BasicBlock {
 
     /// All predecessors of this block
     std::set<BasicBlock *, BBComparitor> predecessors;
+
+    /// @brief All blocks that come after this one
+    std::set<std::shared_ptr<BasicBlock>, BBComparitor> successors;
 
     const uint32_t index;
 

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -580,49 +580,6 @@ class Branch {
     std::string print() const;
 };
 
-/**
- * A think that creates A conditional web.
- *
- * This works such that `if_true` will always point to a Basic block, and
- * `if_false` will either point to andother Condition or nothing. This means
- * that our web will always have a form like:
- *
- *    O --\
- *  /      \
- * O   O --\\
- *  \ /     \\
- *   O   O - O
- *    \ /   /
- *     O   /
- *      \ /
- *       O
- *
- * Because the false condition will itself be a condition.
- *
- * if_false is initialized to nullptr, and one needs to check for that.
- */
-class Condition {
-  public:
-    Condition(Instruction && o);
-    Condition(Instruction && o, std::shared_ptr<CFGNode> s);
-
-    /// An object that is the condition
-    Instruction condition;
-
-    /// The block to go to if the condition is true
-    std::shared_ptr<CFGNode> if_true;
-
-    /// The block to go to if the condition is false
-    std::shared_ptr<CFGNode> if_false;
-
-    /// Print a human readable version of this
-    std::string print() const;
-};
-
-using NextType = std::variant<std::monostate, std::unique_ptr<Condition>, std::shared_ptr<CFGNode>>;
-
-class CFGNode;
-
 class BasicBlock {
   public:
     BasicBlock() = default;
@@ -643,13 +600,9 @@ struct CFGComparitor {
 class CFGNode {
   public:
     CFGNode();
-    CFGNode(std::unique_ptr<Condition> &&);
 
     /// @brief The block instructions
     std::unique_ptr<BasicBlock> block;
-
-    /// Either nothing, a pointer to another CFGNode, or a pointer to a Condition
-    NextType next;
 
     /// All predecessors of this block
     std::set<std::weak_ptr<CFGNode>, CFGComparitor> predecessors;

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -75,7 +75,6 @@ class Phi;
 class IncludeDirectories;
 class Message;
 class Program;
-class Empty;
 class CustomTarget;
 class Dependency;
 class Test;
@@ -85,7 +84,7 @@ class Branch;
 using Object =
     std::variant<std::monostate, FunctionCall, String, Boolean, Number, Identifier, Array, Dict,
                  Compiler, File, Executable, StaticLibrary, Phi, IncludeDirectories, Message,
-                 Program, Empty, CustomTarget, Dependency, Test, AddArguments, Jump, Branch>;
+                 Program, CustomTarget, Dependency, Test, AddArguments, Jump, Branch>;
 
 using Callable = std::variant<File, Executable, Program>;
 
@@ -111,7 +110,6 @@ class Instruction {
     Instruction(File val);
     Instruction(IncludeDirectories val);
     Instruction(Message val);
-    Instruction(Empty val);
     Instruction(Dependency val);
     Instruction(CustomTarget val);
     Instruction(StaticLibrary val);
@@ -388,14 +386,6 @@ class Test {
     std::string print() const;
 };
 
-class Empty {
-  public:
-    Empty() = default;
-
-    /// Print a human readable version of this
-    std::string print() const;
-};
-
 /**
  * Holds a toolchain
  *
@@ -623,6 +613,7 @@ class CFG {
 };
 
 void link_nodes(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor);
-void unlink_nodes(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor);
+void unlink_nodes(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor,
+                  bool recursive = true);
 
 } // namespace MIR

--- a/src/mir/passes.hpp
+++ b/src/mir/passes.hpp
@@ -24,7 +24,7 @@ namespace MIR::Passes {
  * to trim away dead branches and join the ir lists together so we end up with a
  * single flat list of Objects.
  */
-bool branch_pruning(std::shared_ptr<BasicBlock>);
+bool branch_pruning(std::shared_ptr<CFGNode>);
 
 /**
  * Join basic blocks together
@@ -32,7 +32,7 @@ bool branch_pruning(std::shared_ptr<BasicBlock>);
  * Specifically for use after branch_pruning, when we have two continguous
  * blocks with no condition to move between thme
  */
-bool join_blocks(std::shared_ptr<BasicBlock>);
+bool join_blocks(std::shared_ptr<CFGNode>);
 
 /**
  * Lower away machine related information.
@@ -40,13 +40,13 @@ bool join_blocks(std::shared_ptr<BasicBlock>);
  * This replaces function calls to `host_machine`, `build_machine`, and
  * `target_machine` methods with their values.
  */
-bool machine_lower(std::shared_ptr<BasicBlock>,
+bool machine_lower(std::shared_ptr<CFGNode>,
                    const MIR::Machines::PerMachine<MIR::Machines::Info> &);
 
 /**
  * Run complier detection code and replace variables with compiler objects.
  */
-bool insert_compilers(std::shared_ptr<BasicBlock>,
+bool insert_compilers(std::shared_ptr<CFGNode>,
                       const std::unordered_map<
                           MIR::Toolchain::Language,
                           MIR::Machines::PerMachine<std::shared_ptr<MIR::Toolchain::Toolchain>>> &);
@@ -55,14 +55,14 @@ bool insert_compilers(std::shared_ptr<BasicBlock>,
  * Find string arguments to custom_target's program space (intput[0]), and
  * replace it with a call to `find_program()`
  */
-bool custom_target_program_replacement(std::shared_ptr<BasicBlock>);
+bool custom_target_program_replacement(std::shared_ptr<CFGNode>);
 
 /**
  * Lowering for free functions
  *
  * This lowers free standing functions (those not part of an object/namespace).
  */
-bool lower_free_functions(std::shared_ptr<BasicBlock>, const State::Persistant &);
+bool lower_free_functions(std::shared_ptr<CFGNode>, const State::Persistant &);
 
 /**
  * Flatten array arguments to functions.
@@ -84,22 +84,22 @@ bool lower_free_functions(std::shared_ptr<BasicBlock>, const State::Persistant &
  * Meson++ uses this pass to flatten arguments, building an idealized set of
  * arguments for each function.
  */
-bool flatten(std::shared_ptr<BasicBlock>, const State::Persistant &);
+bool flatten(std::shared_ptr<CFGNode>, const State::Persistant &);
 
 struct GlobalValueNumbering {
-    bool operator()(std::shared_ptr<BasicBlock>);
+    bool operator()(std::shared_ptr<CFGNode>);
 
   private:
     std::unordered_map<uint32_t, std::unordered_map<std::string, uint32_t>> data;
     std::unordered_map<std::string, uint32_t> gvn;
     bool number(Instruction &, const uint32_t);
-    bool insert_phis(BasicBlock &);
+    bool insert_phis(CFGNode &);
 };
 
-bool fixup_phis(std::shared_ptr<BasicBlock>);
+bool fixup_phis(std::shared_ptr<CFGNode>);
 
 struct ConstantFolding {
-    bool operator()(std::shared_ptr<BasicBlock>);
+    bool operator()(std::shared_ptr<CFGNode>);
 
   private:
     std::map<Variable, Variable> data;
@@ -110,7 +110,7 @@ struct ConstantFolding {
  * push variables out of assignments into their uses
  */
 struct ConstantPropagation {
-    bool operator()(std::shared_ptr<BasicBlock>);
+    bool operator()(std::shared_ptr<CFGNode>);
 
   private:
     std::map<Variable, Instruction *> data;
@@ -130,21 +130,21 @@ struct ConstantPropagation {
  *
  * These can be done in parallel, using the cache
  */
-bool threaded_lowering(std::shared_ptr<BasicBlock>, State::Persistant & pstate);
+bool threaded_lowering(std::shared_ptr<CFGNode>, State::Persistant & pstate);
 
 /**
  * Lower Program objects and their methods
  */
-bool lower_program_objects(std::shared_ptr<BasicBlock>, State::Persistant & pstate);
+bool lower_program_objects(std::shared_ptr<CFGNode>, State::Persistant & pstate);
 
 /// Lower string object methods
-bool lower_string_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate);
+bool lower_string_objects(std::shared_ptr<CFGNode> block, State::Persistant & pstate);
 
 /// Lower dependency object methods
-bool lower_dependency_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate);
+bool lower_dependency_objects(std::shared_ptr<CFGNode> block, State::Persistant & pstate);
 
 /// Delete any code that has become unreachable
-bool delete_unreachable(std::shared_ptr<BasicBlock> block);
+bool delete_unreachable(std::shared_ptr<CFGNode> block);
 
 /// Debugging pass that dumps a human readable text representation of the IR to
 /// a file.
@@ -153,7 +153,7 @@ class Printer {
   public:
     Printer(uint32_t p = 0);
     ~Printer();
-    bool operator()(const std::shared_ptr<BasicBlock>);
+    bool operator()(const std::shared_ptr<CFGNode>);
     void increment();
     uint32_t pass;
 
@@ -164,6 +164,6 @@ class Printer {
 /// @brief Move AddArgument nodes to the top of the program
 /// @param block The block to operate on
 /// @return true if any work is done, otherwise false
-bool combine_add_arguments(std::shared_ptr<BasicBlock> block);
+bool combine_add_arguments(std::shared_ptr<CFGNode> block);
 
 } // namespace MIR::Passes

--- a/src/mir/passes.hpp
+++ b/src/mir/passes.hpp
@@ -24,7 +24,7 @@ namespace MIR::Passes {
  * to trim away dead branches and join the ir lists together so we end up with a
  * single flat list of Objects.
  */
-bool branch_pruning(BasicBlock &);
+bool branch_pruning(std::shared_ptr<BasicBlock>);
 
 /**
  * Join basic blocks together
@@ -32,7 +32,7 @@ bool branch_pruning(BasicBlock &);
  * Specifically for use after branch_pruning, when we have two continguous
  * blocks with no condition to move between thme
  */
-bool join_blocks(BasicBlock &);
+bool join_blocks(std::shared_ptr<BasicBlock>);
 
 /**
  * Lower away machine related information.
@@ -40,12 +40,13 @@ bool join_blocks(BasicBlock &);
  * This replaces function calls to `host_machine`, `build_machine`, and
  * `target_machine` methods with their values.
  */
-bool machine_lower(BasicBlock &, const MIR::Machines::PerMachine<MIR::Machines::Info> &);
+bool machine_lower(std::shared_ptr<BasicBlock>,
+                   const MIR::Machines::PerMachine<MIR::Machines::Info> &);
 
 /**
  * Run complier detection code and replace variables with compiler objects.
  */
-bool insert_compilers(BasicBlock &,
+bool insert_compilers(std::shared_ptr<BasicBlock>,
                       const std::unordered_map<
                           MIR::Toolchain::Language,
                           MIR::Machines::PerMachine<std::shared_ptr<MIR::Toolchain::Toolchain>>> &);
@@ -54,14 +55,14 @@ bool insert_compilers(BasicBlock &,
  * Find string arguments to custom_target's program space (intput[0]), and
  * replace it with a call to `find_program()`
  */
-bool custom_target_program_replacement(BasicBlock &);
+bool custom_target_program_replacement(std::shared_ptr<BasicBlock>);
 
 /**
  * Lowering for free functions
  *
  * This lowers free standing functions (those not part of an object/namespace).
  */
-bool lower_free_functions(BasicBlock &, const State::Persistant &);
+bool lower_free_functions(std::shared_ptr<BasicBlock>, const State::Persistant &);
 
 /**
  * Flatten array arguments to functions.
@@ -83,10 +84,10 @@ bool lower_free_functions(BasicBlock &, const State::Persistant &);
  * Meson++ uses this pass to flatten arguments, building an idealized set of
  * arguments for each function.
  */
-bool flatten(BasicBlock &, const State::Persistant &);
+bool flatten(std::shared_ptr<BasicBlock>, const State::Persistant &);
 
 struct GlobalValueNumbering {
-    bool operator()(BasicBlock &);
+    bool operator()(std::shared_ptr<BasicBlock>);
 
   private:
     std::unordered_map<uint32_t, std::unordered_map<std::string, uint32_t>> data;
@@ -95,10 +96,10 @@ struct GlobalValueNumbering {
     bool insert_phis(BasicBlock &);
 };
 
-bool fixup_phis(BasicBlock &);
+bool fixup_phis(std::shared_ptr<BasicBlock>);
 
 struct ConstantFolding {
-    bool operator()(BasicBlock &);
+    bool operator()(std::shared_ptr<BasicBlock>);
 
   private:
     std::map<Variable, Variable> data;
@@ -109,7 +110,7 @@ struct ConstantFolding {
  * push variables out of assignments into their uses
  */
 struct ConstantPropagation {
-    bool operator()(BasicBlock &);
+    bool operator()(std::shared_ptr<BasicBlock>);
 
   private:
     std::map<Variable, Instruction *> data;
@@ -129,21 +130,21 @@ struct ConstantPropagation {
  *
  * These can be done in parallel, using the cache
  */
-bool threaded_lowering(BasicBlock &, State::Persistant & pstate);
+bool threaded_lowering(std::shared_ptr<BasicBlock>, State::Persistant & pstate);
 
 /**
  * Lower Program objects and their methods
  */
-bool lower_program_objects(BasicBlock &, State::Persistant & pstate);
+bool lower_program_objects(std::shared_ptr<BasicBlock>, State::Persistant & pstate);
 
 /// Lower string object methods
-bool lower_string_objects(BasicBlock & block, State::Persistant & pstate);
+bool lower_string_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate);
 
 /// Lower dependency object methods
-bool lower_dependency_objects(BasicBlock & block, State::Persistant & pstate);
+bool lower_dependency_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate);
 
 /// Delete any code that has become unreachable
-bool delete_unreachable(BasicBlock & block);
+bool delete_unreachable(std::shared_ptr<BasicBlock> block);
 
 /// Debugging pass that dumps a human readable text representation of the IR to
 /// a file.
@@ -152,7 +153,7 @@ class Printer {
   public:
     Printer(uint32_t p = 0);
     ~Printer();
-    bool operator()(const BasicBlock &);
+    bool operator()(const std::shared_ptr<BasicBlock>);
     void increment();
     uint32_t pass;
 
@@ -163,6 +164,6 @@ class Printer {
 /// @brief Move AddArgument nodes to the top of the program
 /// @param block The block to operate on
 /// @return true if any work is done, otherwise false
-bool combine_add_arguments(BasicBlock & block);
+bool combine_add_arguments(std::shared_ptr<BasicBlock> block);
 
 } // namespace MIR::Passes

--- a/src/mir/passes/combine_add_arguments.cpp
+++ b/src/mir/passes/combine_add_arguments.cpp
@@ -6,7 +6,7 @@
 
 namespace MIR::Passes {
 
-bool combine_add_arguments(std::shared_ptr<BasicBlock> block) {
+bool combine_add_arguments(std::shared_ptr<CFGNode> block) {
     MIR::AddArguments * proj = nullptr;
     MIR::AddArguments * global = nullptr;
 

--- a/src/mir/passes/combine_add_arguments.cpp
+++ b/src/mir/passes/combine_add_arguments.cpp
@@ -6,13 +6,13 @@
 
 namespace MIR::Passes {
 
-bool combine_add_arguments(BasicBlock & block) {
+bool combine_add_arguments(std::shared_ptr<BasicBlock> block) {
     MIR::AddArguments * proj = nullptr;
     MIR::AddArguments * global = nullptr;
 
     bool progress = false;
 
-    for (auto it = block.instructions.begin(); it != block.instructions.end(); ++it) {
+    for (auto it = block->instructions.begin(); it != block->instructions.end(); ++it) {
         if (MIR::AddArguments * a = std::get_if<MIR::AddArguments>(it->obj_ptr.get())) {
             if (a->is_global && global == nullptr) {
                 global = a;
@@ -36,7 +36,7 @@ bool combine_add_arguments(BasicBlock & block) {
                 progress = true;
             }
             // We don't want to go over the same block twice
-            it = ++block.instructions.erase(it);
+            it = ++block->instructions.erase(it);
         }
     }
 

--- a/src/mir/passes/combine_add_arguments.cpp
+++ b/src/mir/passes/combine_add_arguments.cpp
@@ -12,7 +12,8 @@ bool combine_add_arguments(std::shared_ptr<CFGNode> block) {
 
     bool progress = false;
 
-    for (auto it = block->instructions.begin(); it != block->instructions.end(); ++it) {
+    for (auto it = block->block->instructions.begin(); it != block->block->instructions.end();
+         ++it) {
         if (MIR::AddArguments * a = std::get_if<MIR::AddArguments>(it->obj_ptr.get())) {
             if (a->is_global && global == nullptr) {
                 global = a;
@@ -36,7 +37,7 @@ bool combine_add_arguments(std::shared_ptr<CFGNode> block) {
                 progress = true;
             }
             // We don't want to go over the same block twice
-            it = ++block->instructions.erase(it);
+            it = ++block->block->instructions.erase(it);
         }
     }
 

--- a/src/mir/passes/compilers.cpp
+++ b/src/mir/passes/compilers.cpp
@@ -70,7 +70,7 @@ std::optional<Instruction> replace_compiler(const Instruction & obj, const Toolc
 
 } // namespace
 
-bool insert_compilers(std::shared_ptr<BasicBlock> block, const ToolchainMap & toolchains) {
+bool insert_compilers(std::shared_ptr<CFGNode> block, const ToolchainMap & toolchains) {
     const auto cb = [&](const Instruction & obj) { return replace_compiler(obj, toolchains); };
     return function_walker(*block, cb);
 };

--- a/src/mir/passes/compilers.cpp
+++ b/src/mir/passes/compilers.cpp
@@ -72,7 +72,7 @@ std::optional<Instruction> replace_compiler(const Instruction & obj, const Toolc
 
 bool insert_compilers(std::shared_ptr<CFGNode> block, const ToolchainMap & toolchains) {
     const auto cb = [&](const Instruction & obj) { return replace_compiler(obj, toolchains); };
-    return function_walker(*block, cb);
+    return instruction_walker(*block, {cb});
 };
 
 } // namespace MIR::Passes

--- a/src/mir/passes/compilers.cpp
+++ b/src/mir/passes/compilers.cpp
@@ -70,9 +70,9 @@ std::optional<Instruction> replace_compiler(const Instruction & obj, const Toolc
 
 } // namespace
 
-bool insert_compilers(BasicBlock & block, const ToolchainMap & toolchains) {
-    auto cb = [&](const Instruction & obj) { return replace_compiler(obj, toolchains); };
-    return function_walker(block, cb);
+bool insert_compilers(std::shared_ptr<BasicBlock> block, const ToolchainMap & toolchains) {
+    const auto cb = [&](const Instruction & obj) { return replace_compiler(obj, toolchains); };
+    return function_walker(*block, cb);
 };
 
 } // namespace MIR::Passes

--- a/src/mir/passes/constant_folding.cpp
+++ b/src/mir/passes/constant_folding.cpp
@@ -37,8 +37,8 @@ std::optional<Instruction> ConstantFolding::impl(const Instruction & obj) {
     return std::nullopt;
 }
 
-bool ConstantFolding::operator()(BasicBlock & block) {
-    return function_walker(block, [this](Instruction & i) { return this->impl(i); });
+bool ConstantFolding::operator()(std::shared_ptr<BasicBlock> block) {
+    return function_walker(*block, [this](Instruction & i) { return this->impl(i); });
 };
 
 } // namespace MIR::Passes

--- a/src/mir/passes/constant_folding.cpp
+++ b/src/mir/passes/constant_folding.cpp
@@ -9,8 +9,7 @@
 namespace MIR::Passes {
 
 std::optional<Instruction> ConstantFolding::impl(const Instruction & obj) {
-    auto id = std::get_if<Identifier>(obj.obj_ptr.get());
-    if (id != nullptr) {
+    if (auto id = std::get_if<Identifier>(obj.obj_ptr.get())) {
         const Variable new_var{id->value, id->version};
 
         if (const auto & found = data.find(new_var); found != data.end()) {
@@ -38,7 +37,7 @@ std::optional<Instruction> ConstantFolding::impl(const Instruction & obj) {
 }
 
 bool ConstantFolding::operator()(std::shared_ptr<CFGNode> block) {
-    return function_walker(*block, [this](const Instruction & i) { return this->impl(i); });
+    return instruction_walker(*block, {[this](const Instruction & i) { return this->impl(i); }});
 };
 
 } // namespace MIR::Passes

--- a/src/mir/passes/constant_folding.cpp
+++ b/src/mir/passes/constant_folding.cpp
@@ -38,7 +38,7 @@ std::optional<Instruction> ConstantFolding::impl(const Instruction & obj) {
 }
 
 bool ConstantFolding::operator()(std::shared_ptr<CFGNode> block) {
-    return function_walker(*block, [this](Instruction & i) { return this->impl(i); });
+    return function_walker(*block, [this](const Instruction & i) { return this->impl(i); });
 };
 
 } // namespace MIR::Passes

--- a/src/mir/passes/constant_folding.cpp
+++ b/src/mir/passes/constant_folding.cpp
@@ -37,7 +37,7 @@ std::optional<Instruction> ConstantFolding::impl(const Instruction & obj) {
     return std::nullopt;
 }
 
-bool ConstantFolding::operator()(std::shared_ptr<BasicBlock> block) {
+bool ConstantFolding::operator()(std::shared_ptr<CFGNode> block) {
     return function_walker(*block, [this](Instruction & i) { return this->impl(i); });
 };
 

--- a/src/mir/passes/constant_propogation.cpp
+++ b/src/mir/passes/constant_propogation.cpp
@@ -78,7 +78,7 @@ bool ConstantPropagation::impl(Instruction & obj) const {
     return progress;
 }
 
-bool ConstantPropagation::operator()(std::shared_ptr<BasicBlock> block) {
+bool ConstantPropagation::operator()(std::shared_ptr<CFGNode> block) {
     // We have to break this into two walkers because we need to run this furst,
     // then the replacement
     bool progress =

--- a/src/mir/passes/constant_propogation.cpp
+++ b/src/mir/passes/constant_propogation.cpp
@@ -78,11 +78,11 @@ bool ConstantPropagation::impl(Instruction & obj) const {
     return progress;
 }
 
-bool ConstantPropagation::operator()(BasicBlock & block) {
+bool ConstantPropagation::operator()(std::shared_ptr<BasicBlock> block) {
     // We have to break this into two walkers because we need to run this furst,
     // then the replacement
     bool progress =
-        instruction_walker(block, {
+        instruction_walker(*block, {
                                       [this](Instruction & obj) { return this->update_data(obj); },
                                   });
 
@@ -90,7 +90,7 @@ bool ConstantPropagation::operator()(BasicBlock & block) {
     auto && prop_h = [this](Instruction & obj) { return this->impl(obj); };
 
     progress |= instruction_walker(
-        block,
+        *block,
         {
             [&](const Instruction & obj) { return array_walker(obj, prop); },
             [&](Instruction & obj) { return array_walker(obj, prop_h); },

--- a/src/mir/passes/custom_target_program_replacement.cpp
+++ b/src/mir/passes/custom_target_program_replacement.cpp
@@ -51,7 +51,7 @@ bool program_replacement_impl(Instruction & obj) {
 
 } // namespace
 
-bool custom_target_program_replacement(std::shared_ptr<BasicBlock> block) {
+bool custom_target_program_replacement(std::shared_ptr<CFGNode> block) {
     return instruction_walker(*block, {program_replacement_impl});
 }
 

--- a/src/mir/passes/custom_target_program_replacement.cpp
+++ b/src/mir/passes/custom_target_program_replacement.cpp
@@ -51,8 +51,8 @@ bool program_replacement_impl(Instruction & obj) {
 
 } // namespace
 
-bool custom_target_program_replacement(BasicBlock & block) {
-    return instruction_walker(block, {program_replacement_impl});
+bool custom_target_program_replacement(std::shared_ptr<BasicBlock> block) {
+    return instruction_walker(*block, {program_replacement_impl});
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/dead_code.cpp
+++ b/src/mir/passes/dead_code.cpp
@@ -7,38 +7,38 @@
 
 namespace MIR::Passes {
 
-bool delete_unreachable(BasicBlock & block) {
+bool delete_unreachable(std::shared_ptr<BasicBlock> block) {
     // If we see an Message object that is an error, that block will not return,
     // break it's next connection
-    for (auto itr = block.instructions.begin(); itr != block.instructions.end(); ++itr) {
+    for (auto itr = block->instructions.begin(); itr != block->instructions.end(); ++itr) {
         if (auto * m = std::get_if<Message>(itr->obj_ptr.get())) {
             if (m->level == MessageLevel::ERROR) {
                 bool progress = false;
 
                 // Delete any children point to this block
-                if (std::holds_alternative<std::shared_ptr<BasicBlock>>(block.next)) {
-                    auto & b = *std::get<std::shared_ptr<BasicBlock>>(block.next);
-                    b.predecessors.erase(&block);
+                if (std::holds_alternative<std::shared_ptr<BasicBlock>>(block->next)) {
+                    auto & b = *std::get<std::shared_ptr<BasicBlock>>(block->next);
+                    b.predecessors.erase(block);
                     progress = true;
-                } else if (std::holds_alternative<std::unique_ptr<Condition>>(block.next)) {
-                    const auto & con = *std::get<std::unique_ptr<Condition>>(block.next);
+                } else if (std::holds_alternative<std::unique_ptr<Condition>>(block->next)) {
+                    const auto & con = *std::get<std::unique_ptr<Condition>>(block->next);
                     for (const auto & c : {con.if_true, con.if_false}) {
-                        c->predecessors.erase(&block);
+                        c->predecessors.erase(block);
                     }
                     progress = true;
                 }
 
                 // Set next to monostate, there is nothing after this
-                if (!std::holds_alternative<std::monostate>(block.next)) {
+                if (!std::holds_alternative<std::monostate>(block->next)) {
                     progress = true;
-                    block.next = std::monostate{};
+                    block->next = std::monostate{};
                 }
 
-                if (++itr != block.instructions.end()) {
+                if (++itr != block->instructions.end()) {
                     // Delete all instructions after this message, they don't actually exists
                     // This may delete additional errors, but we can't be sure
                     // they're not spurious or caused by the first error
-                    block.instructions.erase(itr, block.instructions.end());
+                    block->instructions.erase(itr, block->instructions.end());
                     progress = true;
                 }
 

--- a/src/mir/passes/dead_code.cpp
+++ b/src/mir/passes/dead_code.cpp
@@ -25,7 +25,8 @@ bool delete_unreachable(std::shared_ptr<CFGNode> block) {
             if (m->level == MessageLevel::ERROR) {
                 bool progress = false;
 
-                for (auto && b : block->successors) {
+                while (!block->successors.empty()) {
+                    auto b = *block->successors.begin();
                     if (keep.find(b) == keep.end()) {
                         unlink_nodes(block, b);
                         progress = true;

--- a/src/mir/passes/dead_code.cpp
+++ b/src/mir/passes/dead_code.cpp
@@ -10,7 +10,7 @@ namespace MIR::Passes {
 bool delete_unreachable(std::shared_ptr<CFGNode> block) {
     // If we see an Message object that is an error, that block will not return,
     // break it's next connection
-    for (auto itr = block->instructions.begin(); itr != block->instructions.end(); ++itr) {
+    for (auto itr = block->block->instructions.begin(); itr != block->block->instructions.end(); ++itr) {
         if (auto * m = std::get_if<Message>(itr->obj_ptr.get())) {
             if (m->level == MessageLevel::ERROR) {
                 bool progress = false;
@@ -34,11 +34,11 @@ bool delete_unreachable(std::shared_ptr<CFGNode> block) {
                     block->next = std::monostate{};
                 }
 
-                if (++itr != block->instructions.end()) {
+                if (++itr != block->block->instructions.end()) {
                     // Delete all instructions after this message, they don't actually exists
                     // This may delete additional errors, but we can't be sure
                     // they're not spurious or caused by the first error
-                    block->instructions.erase(itr, block->instructions.end());
+                    block->block->instructions.erase(itr, block->block->instructions.end());
                     progress = true;
                 }
 

--- a/src/mir/passes/dead_code.cpp
+++ b/src/mir/passes/dead_code.cpp
@@ -10,29 +10,26 @@ namespace MIR::Passes {
 bool delete_unreachable(std::shared_ptr<CFGNode> block) {
     // If we see an Message object that is an error, that block will not return,
     // break it's next connection
+    std::set<std::shared_ptr<CFGNode>, CFGComparitor> keep;
+
     for (auto itr = block->block->instructions.begin(); itr != block->block->instructions.end();
          ++itr) {
-        if (auto * m = std::get_if<Message>(itr->obj_ptr.get())) {
+        if (auto * m = std::get_if<Jump>(itr->obj_ptr.get())) {
+            keep.emplace(m->target);
+        } else if (auto * m = std::get_if<Branch>(itr->obj_ptr.get())) {
+            for (auto && [_, b] : m->branches) {
+                keep.emplace(b);
+            }
+            continue;
+        } else if (auto * m = std::get_if<Message>(itr->obj_ptr.get())) {
             if (m->level == MessageLevel::ERROR) {
                 bool progress = false;
 
-                // Delete any children point to this block
-                if (std::holds_alternative<std::shared_ptr<CFGNode>>(block->next)) {
-                    auto & b = std::get<std::shared_ptr<CFGNode>>(block->next);
-                    unlink_nodes(block, b);
-                    progress = true;
-                } else if (std::holds_alternative<std::unique_ptr<Condition>>(block->next)) {
-                    const auto & con = *std::get<std::unique_ptr<Condition>>(block->next);
-                    for (const auto & c : {con.if_true, con.if_false}) {
-                        unlink_nodes(block, c);
+                for (auto && b : block->successors) {
+                    if (keep.find(b) == keep.end()) {
+                        unlink_nodes(block, b);
+                        progress = true;
                     }
-                    progress = true;
-                }
-
-                // Set next to monostate, there is nothing after this
-                if (!std::holds_alternative<std::monostate>(block->next)) {
-                    progress = true;
-                    block->next = std::monostate{};
                 }
 
                 if (++itr != block->block->instructions.end()) {

--- a/src/mir/passes/dead_code.cpp
+++ b/src/mir/passes/dead_code.cpp
@@ -10,20 +10,21 @@ namespace MIR::Passes {
 bool delete_unreachable(std::shared_ptr<CFGNode> block) {
     // If we see an Message object that is an error, that block will not return,
     // break it's next connection
-    for (auto itr = block->block->instructions.begin(); itr != block->block->instructions.end(); ++itr) {
+    for (auto itr = block->block->instructions.begin(); itr != block->block->instructions.end();
+         ++itr) {
         if (auto * m = std::get_if<Message>(itr->obj_ptr.get())) {
             if (m->level == MessageLevel::ERROR) {
                 bool progress = false;
 
                 // Delete any children point to this block
                 if (std::holds_alternative<std::shared_ptr<CFGNode>>(block->next)) {
-                    auto & b = *std::get<std::shared_ptr<CFGNode>>(block->next);
-                    b.predecessors.erase(block);
+                    auto & b = std::get<std::shared_ptr<CFGNode>>(block->next);
+                    unlink_nodes(block, b);
                     progress = true;
                 } else if (std::holds_alternative<std::unique_ptr<Condition>>(block->next)) {
                     const auto & con = *std::get<std::unique_ptr<Condition>>(block->next);
                     for (const auto & c : {con.if_true, con.if_false}) {
-                        c->predecessors.erase(block);
+                        unlink_nodes(block, c);
                     }
                     progress = true;
                 }

--- a/src/mir/passes/dead_code.cpp
+++ b/src/mir/passes/dead_code.cpp
@@ -7,7 +7,7 @@
 
 namespace MIR::Passes {
 
-bool delete_unreachable(std::shared_ptr<BasicBlock> block) {
+bool delete_unreachable(std::shared_ptr<CFGNode> block) {
     // If we see an Message object that is an error, that block will not return,
     // break it's next connection
     for (auto itr = block->instructions.begin(); itr != block->instructions.end(); ++itr) {
@@ -16,8 +16,8 @@ bool delete_unreachable(std::shared_ptr<BasicBlock> block) {
                 bool progress = false;
 
                 // Delete any children point to this block
-                if (std::holds_alternative<std::shared_ptr<BasicBlock>>(block->next)) {
-                    auto & b = *std::get<std::shared_ptr<BasicBlock>>(block->next);
+                if (std::holds_alternative<std::shared_ptr<CFGNode>>(block->next)) {
+                    auto & b = *std::get<std::shared_ptr<CFGNode>>(block->next);
                     b.predecessors.erase(block);
                     progress = true;
                 } else if (std::holds_alternative<std::unique_ptr<Condition>>(block->next)) {

--- a/src/mir/passes/dead_code.cpp
+++ b/src/mir/passes/dead_code.cpp
@@ -18,12 +18,12 @@ bool delete_unreachable(BasicBlock & block) {
                 // Delete any children point to this block
                 if (std::holds_alternative<std::shared_ptr<BasicBlock>>(block.next)) {
                     auto & b = *std::get<std::shared_ptr<BasicBlock>>(block.next);
-                    b.parents.erase(&block);
+                    b.predecessors.erase(&block);
                     progress = true;
                 } else if (std::holds_alternative<std::unique_ptr<Condition>>(block.next)) {
                     const auto & con = *std::get<std::unique_ptr<Condition>>(block.next);
                     for (const auto & c : {con.if_true, con.if_false}) {
-                        c->parents.erase(&block);
+                        c->predecessors.erase(&block);
                     }
                     progress = true;
                 }

--- a/src/mir/passes/dependency_objects.cpp
+++ b/src/mir/passes/dependency_objects.cpp
@@ -79,7 +79,7 @@ std::optional<Instruction> lower_dependency_methods_impl(const Instruction & obj
 
 } // namespace
 
-bool lower_dependency_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate) {
+bool lower_dependency_objects(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
     return function_walker(*block, [&](const Instruction & obj) {
         return lower_dependency_methods_impl(obj, pstate);
     });

--- a/src/mir/passes/dependency_objects.cpp
+++ b/src/mir/passes/dependency_objects.cpp
@@ -79,9 +79,10 @@ std::optional<Instruction> lower_dependency_methods_impl(const Instruction & obj
 
 } // namespace
 
-bool lower_dependency_objects(BasicBlock & block, State::Persistant & pstate) {
-    return function_walker(
-        block, [&](const Instruction & obj) { return lower_dependency_methods_impl(obj, pstate); });
+bool lower_dependency_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate) {
+    return function_walker(*block, [&](const Instruction & obj) {
+        return lower_dependency_methods_impl(obj, pstate);
+    });
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/dependency_objects.cpp
+++ b/src/mir/passes/dependency_objects.cpp
@@ -80,9 +80,9 @@ std::optional<Instruction> lower_dependency_methods_impl(const Instruction & obj
 } // namespace
 
 bool lower_dependency_objects(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
-    return function_walker(*block, [&](const Instruction & obj) {
+    return instruction_walker(*block, {[&](const Instruction & obj) {
         return lower_dependency_methods_impl(obj, pstate);
-    });
+    }});
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/flatten.cpp
+++ b/src/mir/passes/flatten.cpp
@@ -51,7 +51,7 @@ std::optional<Instruction> flatten_cb(const Instruction & obj) {
 
 bool flatten(std::shared_ptr<CFGNode> block, const State::Persistant & pstate) {
     // TODO: we need to skip this for message, error, and warning
-    return function_walker(*block, flatten_cb);
+    return instruction_walker(*block, {flatten_cb});
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/flatten.cpp
+++ b/src/mir/passes/flatten.cpp
@@ -49,7 +49,7 @@ std::optional<Instruction> flatten_cb(const Instruction & obj) {
 
 } // namespace
 
-bool flatten(std::shared_ptr<BasicBlock> block, const State::Persistant & pstate) {
+bool flatten(std::shared_ptr<CFGNode> block, const State::Persistant & pstate) {
     // TODO: we need to skip this for message, error, and warning
     return function_walker(*block, flatten_cb);
 }

--- a/src/mir/passes/flatten.cpp
+++ b/src/mir/passes/flatten.cpp
@@ -49,9 +49,9 @@ std::optional<Instruction> flatten_cb(const Instruction & obj) {
 
 } // namespace
 
-bool flatten(BasicBlock & block, const State::Persistant & pstate) {
+bool flatten(std::shared_ptr<BasicBlock> block, const State::Persistant & pstate) {
     // TODO: we need to skip this for message, error, and warning
-    return function_walker(block, flatten_cb);
+    return function_walker(*block, flatten_cb);
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -752,8 +752,8 @@ bool all_args_reduced(const std::vector<Instruction> & pos_args,
                        [](auto && kw) { return holds_reduced(kw.second); });
 }
 
-void lower_project(BasicBlock & block, State::Persistant & pstate) {
-    const auto & obj = block.instructions.front();
+void lower_project(std::shared_ptr<BasicBlock> block, State::Persistant & pstate) {
+    const auto & obj = block->instructions.front();
 
     if (!std::holds_alternative<FunctionCall>(*obj.obj_ptr)) {
         throw Util::Exceptions::MesonException{
@@ -812,12 +812,12 @@ void lower_project(BasicBlock & block, State::Persistant & pstate) {
 
     // Remove the valid project() call so we don't accidently find it later when
     // looking for invalid function calls.
-    block.instructions.pop_front();
+    block->instructions.pop_front();
 }
 
-bool lower_free_functions(BasicBlock & block, const State::Persistant & pstate) {
+bool lower_free_functions(std::shared_ptr<BasicBlock> block, const State::Persistant & pstate) {
     return function_walker(
-        block, [&](const Instruction & obj) { return lower_free_funcs_impl(obj, pstate); });
+        *block, [&](const Instruction & obj) { return lower_free_funcs_impl(obj, pstate); });
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -753,7 +753,7 @@ bool all_args_reduced(const std::vector<Instruction> & pos_args,
 }
 
 void lower_project(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
-    const auto & obj = block->instructions.front();
+    const auto & obj = block->block->instructions.front();
 
     if (!std::holds_alternative<FunctionCall>(*obj.obj_ptr)) {
         throw Util::Exceptions::MesonException{
@@ -812,7 +812,7 @@ void lower_project(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
 
     // Remove the valid project() call so we don't accidently find it later when
     // looking for invalid function calls.
-    block->instructions.pop_front();
+    block->block->instructions.pop_front();
 }
 
 bool lower_free_functions(std::shared_ptr<CFGNode> block, const State::Persistant & pstate) {

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -203,7 +203,7 @@ std::optional<Instruction> lower_assert(const FunctionCall & f) {
     }
 
     // TODO: it would be better to
-    return Empty{};
+    return Instruction{std::monostate{}};
 }
 
 std::optional<Instruction> lower_not(const FunctionCall & f) {
@@ -568,7 +568,7 @@ std::optional<Instruction> lower_add_arguments(const FunctionCall & func, const 
         func.name + ": positional arguments must be strings");
     // Meson allows this, so if we don't get any arguments, just return an empty to delete the node
     if (arguments.empty()) {
-        return Empty{};
+        return Instruction{std::monostate{}};
     }
 
     ArgMap mapping;
@@ -683,7 +683,7 @@ std::optional<Instruction> lower_free_funcs_impl(const Instruction & obj,
     const auto & f = std::get<FunctionCall>(*obj.obj_ptr);
 
     // This is not a free function
-    if (!std::holds_alternative<std::monostate>(*f.holder.obj_ptr)) {
+    if (!std::holds_alternative<std::monostate>(f.holder.object())) {
         return std::nullopt;
     }
 
@@ -816,8 +816,8 @@ void lower_project(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
 }
 
 bool lower_free_functions(std::shared_ptr<CFGNode> block, const State::Persistant & pstate) {
-    return function_walker(
-        *block, [&](const Instruction & obj) { return lower_free_funcs_impl(obj, pstate); });
+    return instruction_walker(
+        *block, {[&](const Instruction & obj) { return lower_free_funcs_impl(obj, pstate); }});
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/free_functions.cpp
+++ b/src/mir/passes/free_functions.cpp
@@ -752,7 +752,7 @@ bool all_args_reduced(const std::vector<Instruction> & pos_args,
                        [](auto && kw) { return holds_reduced(kw.second); });
 }
 
-void lower_project(std::shared_ptr<BasicBlock> block, State::Persistant & pstate) {
+void lower_project(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
     const auto & obj = block->instructions.front();
 
     if (!std::holds_alternative<FunctionCall>(*obj.obj_ptr)) {
@@ -815,7 +815,7 @@ void lower_project(std::shared_ptr<BasicBlock> block, State::Persistant & pstate
     block->instructions.pop_front();
 }
 
-bool lower_free_functions(std::shared_ptr<BasicBlock> block, const State::Persistant & pstate) {
+bool lower_free_functions(std::shared_ptr<CFGNode> block, const State::Persistant & pstate) {
     return function_walker(
         *block, [&](const Instruction & obj) { return lower_free_funcs_impl(obj, pstate); });
 }

--- a/src/mir/passes/insert_phis.cpp
+++ b/src/mir/passes/insert_phis.cpp
@@ -6,7 +6,7 @@
 
 namespace MIR::Passes {
 
-bool fixup_phis(std::shared_ptr<BasicBlock> block) {
+bool fixup_phis(std::shared_ptr<CFGNode> block) {
     bool progress = false;
     for (auto it = block->instructions.begin(); it != block->instructions.end(); ++it) {
         if (std::holds_alternative<Phi>(*it->obj_ptr)) {

--- a/src/mir/passes/insert_phis.cpp
+++ b/src/mir/passes/insert_phis.cpp
@@ -13,7 +13,7 @@ bool fixup_phis(BasicBlock & block) {
             const auto & phi = std::get<Phi>(*it->obj_ptr);
             bool right = false;
             bool left = false;
-            for (const auto & p : block.parents) {
+            for (const auto & p : block.predecessors) {
                 for (const Instruction & i : p->instructions) {
                     const auto & var = i.var;
                     if (var.name == it->var.name) {

--- a/src/mir/passes/insert_phis.cpp
+++ b/src/mir/passes/insert_phis.cpp
@@ -8,13 +8,14 @@ namespace MIR::Passes {
 
 bool fixup_phis(std::shared_ptr<CFGNode> block) {
     bool progress = false;
-    for (auto it = block->instructions.begin(); it != block->instructions.end(); ++it) {
+    for (auto it = block->block->instructions.begin(); it != block->block->instructions.end();
+         ++it) {
         if (std::holds_alternative<Phi>(*it->obj_ptr)) {
             const auto & phi = std::get<Phi>(*it->obj_ptr);
             bool right = false;
             bool left = false;
             for (const auto & p : block->predecessors) {
-                for (const Instruction & i : p.lock()->instructions) {
+                for (const Instruction & i : p.lock()->block->instructions) {
                     const auto & var = i.var;
                     if (var.name == it->var.name) {
                         if (var.gvn == phi.left) {
@@ -36,8 +37,8 @@ bool fixup_phis(std::shared_ptr<CFGNode> block) {
                 progress = true;
                 auto id =
                     Instruction{Identifier{it->var.name, left ? phi.left : phi.right}, it->var};
-                it = block->instructions.erase(it);
-                it = block->instructions.emplace(it, std::move(id));
+                it = block->block->instructions.erase(it);
+                it = block->block->instructions.emplace(it, std::move(id));
                 continue;
             }
 
@@ -45,7 +46,7 @@ bool fixup_phis(std::shared_ptr<CFGNode> block) {
             // if one side was found, then the other is found that the first
             // found is dead code after the second, so we can ignore it and
             // treat the second one as the truth
-            for (auto it2 = block->instructions.begin(); it2 != it; ++it2) {
+            for (auto it2 = block->block->instructions.begin(); it2 != it; ++it2) {
                 if (it->var.name == it2->var.name) {
                     left = it2->var.gvn == phi.left;
                     right = it2->var.gvn == phi.right;
@@ -56,8 +57,8 @@ bool fixup_phis(std::shared_ptr<CFGNode> block) {
                 progress = true;
                 auto id =
                     Instruction{Identifier{it->var.name, left ? phi.left : phi.right}, it->var};
-                it = block->instructions.erase(it);
-                it = block->instructions.emplace(it, std::move(id));
+                it = block->block->instructions.erase(it);
+                it = block->block->instructions.emplace(it, std::move(id));
             }
         }
     }

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -17,7 +17,7 @@ bool join_blocks_impl(BasicBlock & block) {
 
     // If the next block has more than one parent we can't join them yet,
     // otherwise the other parent would end up with a pointer to an empty block
-    if (next->parents.size() > 1) {
+    if (next->predecessors.size() > 1) {
         return false;
     }
 
@@ -27,13 +27,13 @@ bool join_blocks_impl(BasicBlock & block) {
     auto nn = std::move(next->next);
     if (std::holds_alternative<std::shared_ptr<BasicBlock>>(nn)) {
         const auto & b = std::get<std::shared_ptr<BasicBlock>>(nn);
-        b->parents.erase(next.get());
-        b->parents.emplace(&block);
+        b->predecessors.erase(next.get());
+        b->predecessors.emplace(&block);
     } else if (std::holds_alternative<std::unique_ptr<Condition>>(nn)) {
         const auto & con = std::get<std::unique_ptr<Condition>>(nn);
         for (const auto & c : {con->if_true, con->if_false}) {
-            c->parents.erase(next.get());
-            c->parents.emplace(&block);
+            c->predecessors.erase(next.get());
+            c->predecessors.emplace(&block);
         }
     }
     block.next = std::move(nn);

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -7,13 +7,13 @@ namespace MIR::Passes {
 
 namespace {
 
-bool join_blocks_impl(std::shared_ptr<BasicBlock> block) {
+bool join_blocks_impl(std::shared_ptr<CFGNode> block) {
     // If there isn't a next block, then we obviously can't do anything
-    if (!std::holds_alternative<std::shared_ptr<BasicBlock>>(block->next)) {
+    if (!std::holds_alternative<std::shared_ptr<CFGNode>>(block->next)) {
         return false;
     }
 
-    auto & next = std::get<std::shared_ptr<BasicBlock>>(block->next);
+    auto & next = std::get<std::shared_ptr<CFGNode>>(block->next);
 
     // If the next block has more than one parent we can't join them yet,
     // otherwise the other parent would end up with a pointer to an empty block
@@ -25,8 +25,8 @@ bool join_blocks_impl(std::shared_ptr<BasicBlock> block) {
     // if neceissry, then make the next block the next->next block.
     block->instructions.splice(block->instructions.end(), next->instructions);
     auto nn = std::move(next->next);
-    if (std::holds_alternative<std::shared_ptr<BasicBlock>>(nn)) {
-        const auto & b = std::get<std::shared_ptr<BasicBlock>>(nn);
+    if (std::holds_alternative<std::shared_ptr<CFGNode>>(nn)) {
+        const auto & b = std::get<std::shared_ptr<CFGNode>>(nn);
         b->predecessors.erase(next);
         b->predecessors.emplace(block);
     } else if (std::holds_alternative<std::unique_ptr<Condition>>(nn)) {
@@ -43,7 +43,7 @@ bool join_blocks_impl(std::shared_ptr<BasicBlock> block) {
 
 } // namespace
 
-bool join_blocks(std::shared_ptr<BasicBlock> block) {
+bool join_blocks(std::shared_ptr<CFGNode> block) {
     bool progress = false;
     bool lprogress;
 

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -23,7 +23,7 @@ bool join_blocks_impl(std::shared_ptr<CFGNode> block) {
 
     // Move the instructions of the next block into this one, then the condition
     // if neceissry, then make the next block the next->next block.
-    block->instructions.splice(block->instructions.end(), next->instructions);
+    block->block->instructions.splice(block->block->instructions.end(), next->block->instructions);
     auto nn = std::move(next->next);
     if (std::holds_alternative<std::shared_ptr<CFGNode>>(nn)) {
         const auto & b = std::get<std::shared_ptr<CFGNode>>(nn);

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -7,13 +7,13 @@ namespace MIR::Passes {
 
 namespace {
 
-bool join_blocks_impl(BasicBlock & block) {
+bool join_blocks_impl(std::shared_ptr<BasicBlock> block) {
     // If there isn't a next block, then we obviously can't do anything
-    if (!std::holds_alternative<std::shared_ptr<BasicBlock>>(block.next)) {
+    if (!std::holds_alternative<std::shared_ptr<BasicBlock>>(block->next)) {
         return false;
     }
 
-    auto & next = std::get<std::shared_ptr<BasicBlock>>(block.next);
+    auto & next = std::get<std::shared_ptr<BasicBlock>>(block->next);
 
     // If the next block has more than one parent we can't join them yet,
     // otherwise the other parent would end up with a pointer to an empty block
@@ -23,27 +23,27 @@ bool join_blocks_impl(BasicBlock & block) {
 
     // Move the instructions of the next block into this one, then the condition
     // if neceissry, then make the next block the next->next block.
-    block.instructions.splice(block.instructions.end(), next->instructions);
+    block->instructions.splice(block->instructions.end(), next->instructions);
     auto nn = std::move(next->next);
     if (std::holds_alternative<std::shared_ptr<BasicBlock>>(nn)) {
         const auto & b = std::get<std::shared_ptr<BasicBlock>>(nn);
-        b->predecessors.erase(next.get());
-        b->predecessors.emplace(&block);
+        b->predecessors.erase(next);
+        b->predecessors.emplace(block);
     } else if (std::holds_alternative<std::unique_ptr<Condition>>(nn)) {
         const auto & con = std::get<std::unique_ptr<Condition>>(nn);
         for (const auto & c : {con->if_true, con->if_false}) {
-            c->predecessors.erase(next.get());
-            c->predecessors.emplace(&block);
+            c->predecessors.erase(next);
+            c->predecessors.emplace(block);
         }
     }
-    block.next = std::move(nn);
+    block->next = std::move(nn);
 
     return true;
 }
 
 } // namespace
 
-bool join_blocks(BasicBlock & block) {
+bool join_blocks(std::shared_ptr<BasicBlock> block) {
     bool progress = false;
     bool lprogress;
 

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -27,13 +27,13 @@ bool join_blocks_impl(std::shared_ptr<CFGNode> block) {
     auto nn = std::move(next->next);
     if (std::holds_alternative<std::shared_ptr<CFGNode>>(nn)) {
         const auto & b = std::get<std::shared_ptr<CFGNode>>(nn);
-        b->predecessors.erase(next);
-        b->predecessors.emplace(block);
+        unlink_nodes(next, b);
+        link_nodes(block, b);
     } else if (std::holds_alternative<std::unique_ptr<Condition>>(nn)) {
         const auto & con = std::get<std::unique_ptr<Condition>>(nn);
         for (const auto & c : {con->if_true, con->if_false}) {
-            c->predecessors.erase(next);
-            c->predecessors.emplace(block);
+            unlink_nodes(next, c);
+            link_nodes(block, c);
         }
     }
     block->next = std::move(nn);

--- a/src/mir/passes/join_blocks.cpp
+++ b/src/mir/passes/join_blocks.cpp
@@ -29,13 +29,15 @@ bool join_blocks_impl(std::shared_ptr<CFGNode> block) {
 
     // Move the predecessors and successors from the next block to the curren
     // tone
-    for (auto && b : next->successors) {
+    for (auto b : next->successors) {
         link_nodes(block, b);
-        unlink_nodes(next, b);
+    }
+    while (!next->successors.empty()) {
+        unlink_nodes(next, *next->successors.begin(), false);
     }
     // Move the instructions
     block->block->instructions.splice(block->block->instructions.end(), next->block->instructions);
-    unlink_nodes(block, next);
+    unlink_nodes(block, next, false);
 
     return true;
 }

--- a/src/mir/passes/machines.cpp
+++ b/src/mir/passes/machines.cpp
@@ -66,10 +66,10 @@ std::optional<Instruction> lower_functions(const MachineInfo & machines, const I
 
 } // namespace
 
-bool machine_lower(BasicBlock & block, const MachineInfo & machines) {
+bool machine_lower(std::shared_ptr<BasicBlock> block, const MachineInfo & machines) {
     const auto cb = [&](const Instruction & o) { return lower_functions(machines, o); };
 
-    return function_walker(block, cb);
+    return function_walker(*block, cb);
 };
 
 } // namespace MIR::Passes

--- a/src/mir/passes/machines.cpp
+++ b/src/mir/passes/machines.cpp
@@ -66,7 +66,7 @@ std::optional<Instruction> lower_functions(const MachineInfo & machines, const I
 
 } // namespace
 
-bool machine_lower(std::shared_ptr<BasicBlock> block, const MachineInfo & machines) {
+bool machine_lower(std::shared_ptr<CFGNode> block, const MachineInfo & machines) {
     const auto cb = [&](const Instruction & o) { return lower_functions(machines, o); };
 
     return function_walker(*block, cb);

--- a/src/mir/passes/machines.cpp
+++ b/src/mir/passes/machines.cpp
@@ -69,7 +69,7 @@ std::optional<Instruction> lower_functions(const MachineInfo & machines, const I
 bool machine_lower(std::shared_ptr<CFGNode> block, const MachineInfo & machines) {
     const auto cb = [&](const Instruction & o) { return lower_functions(machines, o); };
 
-    return function_walker(*block, cb);
+    return instruction_walker(*block, {cb});
 };
 
 } // namespace MIR::Passes

--- a/src/mir/passes/print.cpp
+++ b/src/mir/passes/print.cpp
@@ -24,7 +24,7 @@ void condition_printer(const Condition & cond, std::ofstream & stream) {
 void printer_impl(const CFGNode & block, std::ofstream & stream) {
     // Only print a given block once
     stream << "  CFGNode " << block.index << " {\n";
-    for (auto && i : block.instructions) {
+    for (auto && i : block.block->instructions) {
         stream << "    " << i.print() << "\n";
     }
     std::visit(

--- a/src/mir/passes/print.cpp
+++ b/src/mir/passes/print.cpp
@@ -21,9 +21,9 @@ void condition_printer(const Condition & cond, std::ofstream & stream) {
            << "  }\n";
 }
 
-void printer_impl(const BasicBlock & block, std::ofstream & stream) {
+void printer_impl(const CFGNode & block, std::ofstream & stream) {
     // Only print a given block once
-    stream << "  BasicBlock " << block.index << " {\n";
+    stream << "  CFGNode " << block.index << " {\n";
     for (auto && i : block.instructions) {
         stream << "    " << i.print() << "\n";
     }
@@ -32,7 +32,7 @@ void printer_impl(const BasicBlock & block, std::ofstream & stream) {
             using T = std::decay_t<decltype(n)>;
             if constexpr (std::is_same_v<T, std::unique_ptr<Condition>>) {
                 condition_printer(*n, stream);
-            } else if constexpr (std::is_same_v<T, std::shared_ptr<BasicBlock>>) {
+            } else if constexpr (std::is_same_v<T, std::shared_ptr<CFGNode>>) {
                 stream << "    next block: " << n->index << "\n"
                        << "  }\n";
             } else {
@@ -70,7 +70,7 @@ void Printer::increment() {
     }
 }
 
-bool Printer::operator()(const std::shared_ptr<BasicBlock> block) {
+bool Printer::operator()(const std::shared_ptr<CFGNode> block) {
     if (out.is_open()) {
         printer_impl(*block, out);
     }

--- a/src/mir/passes/print.cpp
+++ b/src/mir/passes/print.cpp
@@ -70,9 +70,9 @@ void Printer::increment() {
     }
 }
 
-bool Printer::operator()(const BasicBlock & block) {
+bool Printer::operator()(const std::shared_ptr<BasicBlock> block) {
     if (out.is_open()) {
-        printer_impl(block, out);
+        printer_impl(*block, out);
     }
 
     // Always return false, because the print pass doesn't ever make an progress

--- a/src/mir/passes/private.hpp
+++ b/src/mir/passes/private.hpp
@@ -19,25 +19,25 @@ using ReplacementCallback = std::function<std::optional<Instruction>(Instruction
 using MutationCallback = std::function<bool(Instruction &)>;
 
 /// Callback to pass to a BlockWalker, probably an instruction_walker
-using BlockWalkerCb = std::function<bool(std::shared_ptr<BasicBlock>)>;
+using BlockWalkerCb = std::function<bool(std::shared_ptr<CFGNode>)>;
 
 /**
  * Walks each instruction in a basic block, calling each callback on each instruction
  *
  * Returns true if any changes were made to the block.
  */
-bool instruction_walker(BasicBlock &, const std::vector<MutationCallback> &,
+bool instruction_walker(CFGNode &, const std::vector<MutationCallback> &,
                         const std::vector<ReplacementCallback> &);
-bool instruction_walker(BasicBlock &, const std::vector<MutationCallback> &);
-bool instruction_walker(BasicBlock &, const std::vector<ReplacementCallback> &);
+bool instruction_walker(CFGNode &, const std::vector<MutationCallback> &);
+bool instruction_walker(CFGNode &, const std::vector<ReplacementCallback> &);
 
 /**
  * Walks the isntructions of a basic block calling each callback on Function it fins
  *
  * It is the job of each function callback to only act on functions it means to.
  */
-bool function_walker(BasicBlock &, const ReplacementCallback &);
-bool function_walker(BasicBlock &, const MutationCallback &);
+bool function_walker(CFGNode &, const ReplacementCallback &);
+bool function_walker(CFGNode &, const MutationCallback &);
 
 /**
  * Walk each instruction in an array, recursively, calling the callbck on them.
@@ -56,7 +56,7 @@ bool function_argument_walker(Instruction &, const MutationCallback &);
 /**
  * Walker over all basic blocks starting with the provided one, applying the given callbacks
  */
-bool block_walker(std::shared_ptr<BasicBlock>, const std::vector<BlockWalkerCb> &);
+bool block_walker(std::shared_ptr<CFGNode>, const std::vector<BlockWalkerCb> &);
 
 /// Check if all of the arguments have been reduced from ids
 bool all_args_reduced(const std::vector<Instruction> & pos_args,

--- a/src/mir/passes/private.hpp
+++ b/src/mir/passes/private.hpp
@@ -13,7 +13,7 @@
 namespace MIR::Passes {
 
 /// Callback will return a an optional Instruction, when it does the original object is replaced
-using ReplacementCallback = std::function<std::optional<Instruction>(Instruction &)>;
+using ReplacementCallback = std::function<std::optional<Instruction>(const Instruction &)>;
 
 /// Callback will return a boolean that progress is mode
 using MutationCallback = std::function<bool(Instruction &)>;

--- a/src/mir/passes/private.hpp
+++ b/src/mir/passes/private.hpp
@@ -32,28 +32,6 @@ bool instruction_walker(CFGNode &, const std::vector<MutationCallback> &);
 bool instruction_walker(CFGNode &, const std::vector<ReplacementCallback> &);
 
 /**
- * Walks the isntructions of a basic block calling each callback on Function it fins
- *
- * It is the job of each function callback to only act on functions it means to.
- */
-bool function_walker(CFGNode &, const ReplacementCallback &);
-bool function_walker(CFGNode &, const MutationCallback &);
-
-/**
- * Walk each instruction in an array, recursively, calling the callbck on them.
- */
-bool array_walker(const Instruction &, const ReplacementCallback &);
-bool array_walker(Instruction &, const MutationCallback &);
-
-/**
- * Walk over the arguments (positional and keyword) of a function
- *
- * This will replace the arguments if they are loweed by the callback
- */
-bool function_argument_walker(const Instruction &, const ReplacementCallback &);
-bool function_argument_walker(Instruction &, const MutationCallback &);
-
-/**
  * Walker over all basic blocks starting with the provided one, applying the given callbacks
  */
 bool graph_walker(std::shared_ptr<CFGNode>, const std::vector<BlockWalkerCb> &);

--- a/src/mir/passes/private.hpp
+++ b/src/mir/passes/private.hpp
@@ -56,7 +56,7 @@ bool function_argument_walker(Instruction &, const MutationCallback &);
 /**
  * Walker over all basic blocks starting with the provided one, applying the given callbacks
  */
-bool block_walker(std::shared_ptr<CFGNode>, const std::vector<BlockWalkerCb> &);
+bool graph_walker(std::shared_ptr<CFGNode>, const std::vector<BlockWalkerCb> &);
 
 /// Check if all of the arguments have been reduced from ids
 bool all_args_reduced(const std::vector<Instruction> & pos_args,

--- a/src/mir/passes/private.hpp
+++ b/src/mir/passes/private.hpp
@@ -19,7 +19,7 @@ using ReplacementCallback = std::function<std::optional<Instruction>(Instruction
 using MutationCallback = std::function<bool(Instruction &)>;
 
 /// Callback to pass to a BlockWalker, probably an instruction_walker
-using BlockWalkerCb = std::function<bool(BasicBlock &)>;
+using BlockWalkerCb = std::function<bool(std::shared_ptr<BasicBlock>)>;
 
 /**
  * Walks each instruction in a basic block, calling each callback on each instruction
@@ -56,7 +56,7 @@ bool function_argument_walker(Instruction &, const MutationCallback &);
 /**
  * Walker over all basic blocks starting with the provided one, applying the given callbacks
  */
-bool block_walker(BasicBlock &, const std::vector<BlockWalkerCb> &);
+bool block_walker(std::shared_ptr<BasicBlock>, const std::vector<BlockWalkerCb> &);
 
 /// Check if all of the arguments have been reduced from ids
 bool all_args_reduced(const std::vector<Instruction> & pos_args,

--- a/src/mir/passes/program_objects.cpp
+++ b/src/mir/passes/program_objects.cpp
@@ -52,8 +52,8 @@ std::optional<Instruction> lower_program_methods_impl(const Instruction & obj,
 } // namespace
 
 bool lower_program_objects(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
-    return function_walker(
-        *block, [&](const Instruction & obj) { return lower_program_methods_impl(obj, pstate); });
+    return instruction_walker(
+        *block, {[&](const Instruction & obj) { return lower_program_methods_impl(obj, pstate); }});
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/program_objects.cpp
+++ b/src/mir/passes/program_objects.cpp
@@ -51,9 +51,9 @@ std::optional<Instruction> lower_program_methods_impl(const Instruction & obj,
 
 } // namespace
 
-bool lower_program_objects(BasicBlock & block, State::Persistant & pstate) {
+bool lower_program_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate) {
     return function_walker(
-        block, [&](const Instruction & obj) { return lower_program_methods_impl(obj, pstate); });
+        *block, [&](const Instruction & obj) { return lower_program_methods_impl(obj, pstate); });
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/program_objects.cpp
+++ b/src/mir/passes/program_objects.cpp
@@ -51,7 +51,7 @@ std::optional<Instruction> lower_program_methods_impl(const Instruction & obj,
 
 } // namespace
 
-bool lower_program_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate) {
+bool lower_program_objects(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
     return function_walker(
         *block, [&](const Instruction & obj) { return lower_program_methods_impl(obj, pstate); });
 }

--- a/src/mir/passes/pruning.cpp
+++ b/src/mir/passes/pruning.cpp
@@ -29,16 +29,17 @@ bool branch_pruning_impl(std::shared_ptr<CFGNode> ir) {
     // next and condition, otherwise move the `else` branch to be the main condition, and
     // continue
     const bool & con_v = std::get<Boolean>(*con.condition.obj_ptr).value;
-    std::shared_ptr<CFGNode> next;
+    std::shared_ptr<CFGNode> next, remove;
     if (con_v) {
         assert(con.if_true != nullptr);
         next = con.if_true;
-        todo.emplace_back(con.if_false);
+        remove = con.if_false;
     } else {
         assert(con.if_false != nullptr);
         next = con.if_false;
-        todo.emplace_back(con.if_true);
+        remove = con.if_true;
     }
+    todo.emplace_back(remove);
 
     // When we prune this, we need to all remove it from any successor blocks
     // predecessors' so that we dont reference a dangling pointer
@@ -80,6 +81,7 @@ bool branch_pruning_impl(std::shared_ptr<CFGNode> ir) {
     }
 
     next->predecessors = {ir};
+    ir->successors.erase(remove);
     ir->next = next;
 
     return true;

--- a/src/mir/passes/pruning.cpp
+++ b/src/mir/passes/pruning.cpp
@@ -41,14 +41,14 @@ bool branch_pruning_impl(BasicBlock & ir) {
     }
 
     // When we prune this, we need to all remove it from any successor blocks
-    // parents' so that we dont reference a dangling pointer
+    // predecessors' so that we dont reference a dangling pointer
 
     // Blocks that have already been visited
     std::set<BasicBlock *, BBComparitor> visited{};
 
     // Walk down the CFG of the block we're about to prune until we find a block
-    // with parents that aren't visited or todo items, that is the convergance point
-    // Then remove this path from that block's parents.
+    // with predecessors that aren't visited or todo items, that is the convergance point
+    // Then remove this path from that block's predecessors.
     while (!todo.empty()) {
         auto * current = todo.back();
         todo.pop_back();
@@ -70,16 +70,16 @@ bool branch_pruning_impl(BasicBlock & ir) {
 
         auto bb = std::get<std::shared_ptr<BasicBlock>>(current->next).get();
 
-        std::set<BasicBlock *, BBComparitor> new_parents{};
-        for (const auto & p : bb->parents) {
+        std::set<BasicBlock *, BBComparitor> new_predecessors{};
+        for (const auto & p : bb->predecessors) {
             if (!(visited.count(p) || std::count(todo.begin(), todo.end(), p))) {
-                new_parents.emplace(p);
+                new_predecessors.emplace(p);
             }
         }
-        bb->parents = new_parents;
+        bb->predecessors = new_predecessors;
     }
 
-    next->parents = {&ir};
+    next->predecessors = {&ir};
     ir.next = next;
 
     return true;

--- a/src/mir/passes/string_objects.cpp
+++ b/src/mir/passes/string_objects.cpp
@@ -96,8 +96,8 @@ std::optional<Instruction> lower_string_methods_impl(const Instruction & obj,
 } // namespace
 
 bool lower_string_objects(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
-    return function_walker(
-        *block, [&](const Instruction & obj) { return lower_string_methods_impl(obj, pstate); });
+    return instruction_walker(
+        *block, {[&](const Instruction & obj) { return lower_string_methods_impl(obj, pstate); }});
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/string_objects.cpp
+++ b/src/mir/passes/string_objects.cpp
@@ -95,9 +95,9 @@ std::optional<Instruction> lower_string_methods_impl(const Instruction & obj,
 
 } // namespace
 
-bool lower_string_objects(BasicBlock & block, State::Persistant & pstate) {
+bool lower_string_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate) {
     return function_walker(
-        block, [&](const Instruction & obj) { return lower_string_methods_impl(obj, pstate); });
+        *block, [&](const Instruction & obj) { return lower_string_methods_impl(obj, pstate); });
 }
 
 } // namespace MIR::Passes

--- a/src/mir/passes/string_objects.cpp
+++ b/src/mir/passes/string_objects.cpp
@@ -95,7 +95,7 @@ std::optional<Instruction> lower_string_methods_impl(const Instruction & obj,
 
 } // namespace
 
-bool lower_string_objects(std::shared_ptr<BasicBlock> block, State::Persistant & pstate) {
+bool lower_string_objects(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
     return function_walker(
         *block, [&](const Instruction & obj) { return lower_string_methods_impl(obj, pstate); });
 }

--- a/src/mir/passes/tests/branch_pruning_test.cpp
+++ b/src/mir/passes/tests/branch_pruning_test.cpp
@@ -35,10 +35,10 @@ TEST(branch_pruning, next_block) {
 
     const auto & next = get_bb(irlist.next);
     ASSERT_EQ(next->instructions.size(), 1);
-    ASSERT_EQ(next->parents.size(), 1);
-    ASSERT_TRUE(next->parents.count(&irlist));
+    ASSERT_EQ(next->predecessors.size(), 1);
+    ASSERT_TRUE(next->predecessors.count(&irlist));
 
-    ASSERT_EQ(get_bb(next->next)->parents.count(next.get()), 1);
+    ASSERT_EQ(get_bb(next->next)->predecessors.count(next.get()), 1);
 }
 
 TEST(branch_pruning, if_else) {

--- a/src/mir/passes/tests/branch_pruning_test.cpp
+++ b/src/mir/passes/tests/branch_pruning_test.cpp
@@ -10,7 +10,7 @@
 
 TEST(branch_pruning, simple) {
     auto irlist = lower("x = 7\nif true\n x = 8\nendif\n");
-    bool progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
 
@@ -28,7 +28,7 @@ TEST(branch_pruning, next_block) {
         endif
         y = x
         )EOF");
-    bool progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
     ASSERT_TRUE(is_bb(irlist->next));
@@ -36,9 +36,9 @@ TEST(branch_pruning, next_block) {
     const auto & next = get_bb(irlist->next);
     ASSERT_EQ(next->instructions.size(), 1);
     ASSERT_EQ(next->predecessors.size(), 1);
-    ASSERT_TRUE(next->predecessors.count(irlist.get()));
+    ASSERT_TRUE(next->predecessors.count(irlist));
 
-    ASSERT_EQ(get_bb(next->next)->predecessors.count(next.get()), 1);
+    ASSERT_EQ(get_bb(next->next)->predecessors.count(next), 1);
 }
 
 TEST(branch_pruning, if_else) {
@@ -50,7 +50,7 @@ TEST(branch_pruning, if_else) {
           x = 9
         endif
         )EOF");
-    bool progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
 
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
@@ -73,7 +73,7 @@ TEST(branch_pruning, if_false) {
           y = 2
         endif
         )EOF");
-    bool progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
 

--- a/src/mir/passes/tests/branch_pruning_test.cpp
+++ b/src/mir/passes/tests/branch_pruning_test.cpp
@@ -10,7 +10,7 @@
 
 TEST(branch_pruning, simple) {
     auto irlist = lower("x = 7\nif true\n x = 8\nendif\n");
-    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
 
@@ -28,7 +28,7 @@ TEST(branch_pruning, next_block) {
         endif
         y = x
         )EOF");
-    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
     ASSERT_TRUE(is_bb(irlist->next));
@@ -50,7 +50,7 @@ TEST(branch_pruning, if_else) {
           x = 9
         endif
         )EOF");
-    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
 
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
@@ -73,7 +73,7 @@ TEST(branch_pruning, if_false) {
           y = 2
         endif
         )EOF");
-    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
 

--- a/src/mir/passes/tests/branch_pruning_test.cpp
+++ b/src/mir/passes/tests/branch_pruning_test.cpp
@@ -10,12 +10,12 @@
 
 TEST(branch_pruning, simple) {
     auto irlist = lower("x = 7\nif true\n x = 8\nendif\n");
-    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    ASSERT_TRUE(is_bb(irlist.next));
-    const auto & next = get_bb(irlist.next);
+    ASSERT_TRUE(is_bb(irlist->next));
+    const auto & next = get_bb(irlist->next);
     ASSERT_FALSE(is_con(next->next));
     ASSERT_EQ(next->instructions.size(), 1);
 }
@@ -28,15 +28,15 @@ TEST(branch_pruning, next_block) {
         endif
         y = x
         )EOF");
-    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    ASSERT_TRUE(is_bb(irlist.next));
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_TRUE(is_bb(irlist->next));
 
-    const auto & next = get_bb(irlist.next);
+    const auto & next = get_bb(irlist->next);
     ASSERT_EQ(next->instructions.size(), 1);
     ASSERT_EQ(next->predecessors.size(), 1);
-    ASSERT_TRUE(next->predecessors.count(&irlist));
+    ASSERT_TRUE(next->predecessors.count(irlist.get()));
 
     ASSERT_EQ(get_bb(next->next)->predecessors.count(next.get()), 1);
 }
@@ -50,13 +50,13 @@ TEST(branch_pruning, if_else) {
           x = 9
         endif
         )EOF");
-    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::branch_pruning});
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    ASSERT_TRUE(is_bb(irlist.next));
-    const auto & next = get_bb(irlist.next);
+    ASSERT_TRUE(is_bb(irlist->next));
+    const auto & next = get_bb(irlist->next);
     ASSERT_EQ(next->instructions.size(), 1);
 
     ASSERT_TRUE(is_bb(next->next));
@@ -73,12 +73,12 @@ TEST(branch_pruning, if_false) {
           y = 2
         endif
         )EOF");
-    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    ASSERT_TRUE(is_bb(irlist.next));
-    const auto & next = get_bb(irlist.next);
+    ASSERT_TRUE(is_bb(irlist->next));
+    const auto & next = get_bb(irlist->next);
     ASSERT_EQ(next->instructions.size(), 2);
 
     const auto & first = std::get<MIR::Number>(*next->instructions.front().obj_ptr);

--- a/src/mir/passes/tests/branch_pruning_test.cpp
+++ b/src/mir/passes/tests/branch_pruning_test.cpp
@@ -12,12 +12,12 @@ TEST(branch_pruning, simple) {
     auto irlist = lower("x = 7\nif true\n x = 8\nendif\n");
     bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
     ASSERT_TRUE(is_bb(irlist->next));
     const auto & next = get_bb(irlist->next);
     ASSERT_FALSE(is_con(next->next));
-    ASSERT_EQ(next->instructions.size(), 1);
+    ASSERT_EQ(next->block->instructions.size(), 1);
 }
 
 TEST(branch_pruning, next_block) {
@@ -30,11 +30,11 @@ TEST(branch_pruning, next_block) {
         )EOF");
     bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
     ASSERT_TRUE(is_bb(irlist->next));
 
     const auto & next = get_bb(irlist->next);
-    ASSERT_EQ(next->instructions.size(), 1);
+    ASSERT_EQ(next->block->instructions.size(), 1);
     ASSERT_EQ(next->predecessors.size(), 1);
     ASSERT_TRUE(next->predecessors.count(irlist));
 
@@ -53,14 +53,14 @@ TEST(branch_pruning, if_else) {
     bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
     ASSERT_TRUE(is_bb(irlist->next));
     const auto & next = get_bb(irlist->next);
-    ASSERT_EQ(next->instructions.size(), 1);
+    ASSERT_EQ(next->block->instructions.size(), 1);
 
     ASSERT_TRUE(is_bb(next->next));
-    ASSERT_TRUE(get_bb(next->next)->instructions.empty());
+    ASSERT_TRUE(get_bb(next->next)->block->instructions.empty());
 }
 
 TEST(branch_pruning, if_false) {
@@ -75,17 +75,17 @@ TEST(branch_pruning, if_false) {
         )EOF");
     bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
     ASSERT_TRUE(is_bb(irlist->next));
     const auto & next = get_bb(irlist->next);
-    ASSERT_EQ(next->instructions.size(), 2);
+    ASSERT_EQ(next->block->instructions.size(), 2);
 
-    const auto & first = std::get<MIR::Number>(*next->instructions.front().obj_ptr);
+    const auto & first = std::get<MIR::Number>(*next->block->instructions.front().obj_ptr);
     ASSERT_EQ(first.value, 9);
-    ASSERT_EQ(next->instructions.front().var.name, "x");
+    ASSERT_EQ(next->block->instructions.front().var.name, "x");
 
-    const auto & last = std::get<MIR::Number>(*next->instructions.back().obj_ptr);
+    const auto & last = std::get<MIR::Number>(*next->block->instructions.back().obj_ptr);
     ASSERT_EQ(last.value, 2);
-    ASSERT_EQ(next->instructions.back().var.name, "y");
+    ASSERT_EQ(next->block->instructions.back().var.name, "y");
 }

--- a/src/mir/passes/tests/const_folding_test.cpp
+++ b/src/mir/passes/tests/const_folding_test.cpp
@@ -18,7 +18,7 @@ TEST(constant_folding, simple) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                            MIR::Passes::GlobalValueNumbering{},
                                            MIR::Passes::ConstantFolding{},
                                        });
@@ -51,10 +51,10 @@ TEST(constant_folding, with_phi) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                            MIR::Passes::GlobalValueNumbering{},
                                        });
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                            MIR::Passes::branch_pruning,
                                            MIR::Passes::join_blocks,
                                            MIR::Passes::fixup_phis,
@@ -117,7 +117,7 @@ TEST(constant_folding, three_statements) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                            MIR::Passes::GlobalValueNumbering{},
                                            MIR::Passes::ConstantFolding{},
                                        });
@@ -145,7 +145,7 @@ TEST(constant_folding, redefined_value) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                            MIR::Passes::GlobalValueNumbering{},
                                            MIR::Passes::ConstantFolding{},
                                        });
@@ -172,7 +172,7 @@ TEST(constant_folding, in_array) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                            MIR::Passes::GlobalValueNumbering{},
                                            MIR::Passes::ConstantFolding{},
                                        });

--- a/src/mir/passes/tests/const_folding_test.cpp
+++ b/src/mir/passes/tests/const_folding_test.cpp
@@ -23,9 +23,9 @@ TEST(constant_folding, simple) {
                                           MIR::Passes::ConstantFolding{},
                                       });
 
-    ASSERT_EQ(irlist->instructions.size(), 3);
+    ASSERT_EQ(irlist->block->instructions.size(), 3);
 
-    const auto & func_obj = irlist->instructions.back();
+    const auto & func_obj = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
     const auto & func = std::get<MIR::FunctionCall>(*func_obj.obj_ptr);
     ASSERT_EQ(func.pos_args.size(), 1);
@@ -61,7 +61,7 @@ TEST(constant_folding, with_phi) {
                                           MIR::Passes::ConstantFolding{},
                                       });
 
-    auto it = irlist->instructions.begin();
+    auto it = irlist->block->instructions.begin();
 
     ASSERT_EQ(it->var.gvn, 2);
     ASSERT_EQ(it->var.name, "x");
@@ -122,7 +122,7 @@ TEST(constant_folding, three_statements) {
                                           MIR::Passes::ConstantFolding{},
                                       });
 
-    const auto & func_obj = irlist->instructions.back();
+    const auto & func_obj = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
     const auto & func = std::get<MIR::FunctionCall>(*func_obj.obj_ptr);
     ASSERT_EQ(func.pos_args.size(), 1);
@@ -150,7 +150,7 @@ TEST(constant_folding, redefined_value) {
                                           MIR::Passes::ConstantFolding{},
                                       });
 
-    const auto & func_obj = irlist->instructions.back();
+    const auto & func_obj = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
     const auto & func = std::get<MIR::FunctionCall>(*func_obj.obj_ptr);
     ASSERT_EQ(func.pos_args.size(), 1);
@@ -177,7 +177,7 @@ TEST(constant_folding, in_array) {
                                           MIR::Passes::ConstantFolding{},
                                       });
 
-    auto it = irlist->instructions.begin();
+    auto it = irlist->block->instructions.begin();
     {
         const auto & id_obj = *it;
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*id_obj.obj_ptr));

--- a/src/mir/passes/tests/const_folding_test.cpp
+++ b/src/mir/passes/tests/const_folding_test.cpp
@@ -18,14 +18,14 @@ TEST(constant_folding, simple) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
-                                          MIR::Passes::GlobalValueNumbering{},
-                                          MIR::Passes::ConstantFolding{},
-                                      });
+    MIR::Passes::block_walker(*irlist, {
+                                           MIR::Passes::GlobalValueNumbering{},
+                                           MIR::Passes::ConstantFolding{},
+                                       });
 
-    ASSERT_EQ(irlist.instructions.size(), 3);
+    ASSERT_EQ(irlist->instructions.size(), 3);
 
-    const auto & func_obj = irlist.instructions.back();
+    const auto & func_obj = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
     const auto & func = std::get<MIR::FunctionCall>(*func_obj.obj_ptr);
     ASSERT_EQ(func.pos_args.size(), 1);
@@ -51,17 +51,17 @@ TEST(constant_folding, with_phi) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(irlist, {
-                                          MIR::Passes::GlobalValueNumbering{},
-                                      });
-    MIR::Passes::block_walker(irlist, {
-                                          MIR::Passes::branch_pruning,
-                                          MIR::Passes::join_blocks,
-                                          MIR::Passes::fixup_phis,
-                                          MIR::Passes::ConstantFolding{},
-                                      });
+    MIR::Passes::block_walker(*irlist, {
+                                           MIR::Passes::GlobalValueNumbering{},
+                                       });
+    MIR::Passes::block_walker(*irlist, {
+                                           MIR::Passes::branch_pruning,
+                                           MIR::Passes::join_blocks,
+                                           MIR::Passes::fixup_phis,
+                                           MIR::Passes::ConstantFolding{},
+                                       });
 
-    auto it = irlist.instructions.begin();
+    auto it = irlist->instructions.begin();
 
     ASSERT_EQ(it->var.gvn, 2);
     ASSERT_EQ(it->var.name, "x");
@@ -117,12 +117,12 @@ TEST(constant_folding, three_statements) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
-                                          MIR::Passes::GlobalValueNumbering{},
-                                          MIR::Passes::ConstantFolding{},
-                                      });
+    MIR::Passes::block_walker(*irlist, {
+                                           MIR::Passes::GlobalValueNumbering{},
+                                           MIR::Passes::ConstantFolding{},
+                                       });
 
-    const auto & func_obj = irlist.instructions.back();
+    const auto & func_obj = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
     const auto & func = std::get<MIR::FunctionCall>(*func_obj.obj_ptr);
     ASSERT_EQ(func.pos_args.size(), 1);
@@ -145,12 +145,12 @@ TEST(constant_folding, redefined_value) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
-                                          MIR::Passes::GlobalValueNumbering{},
-                                          MIR::Passes::ConstantFolding{},
-                                      });
+    MIR::Passes::block_walker(*irlist, {
+                                           MIR::Passes::GlobalValueNumbering{},
+                                           MIR::Passes::ConstantFolding{},
+                                       });
 
-    const auto & func_obj = irlist.instructions.back();
+    const auto & func_obj = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
     const auto & func = std::get<MIR::FunctionCall>(*func_obj.obj_ptr);
     ASSERT_EQ(func.pos_args.size(), 1);
@@ -172,12 +172,12 @@ TEST(constant_folding, in_array) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(irlist, {
-                                          MIR::Passes::GlobalValueNumbering{},
-                                          MIR::Passes::ConstantFolding{},
-                                      });
+    MIR::Passes::block_walker(*irlist, {
+                                           MIR::Passes::GlobalValueNumbering{},
+                                           MIR::Passes::ConstantFolding{},
+                                       });
 
-    auto it = irlist.instructions.begin();
+    auto it = irlist->instructions.begin();
     {
         const auto & id_obj = *it;
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*id_obj.obj_ptr));

--- a/src/mir/passes/tests/const_folding_test.cpp
+++ b/src/mir/passes/tests/const_folding_test.cpp
@@ -63,46 +63,46 @@ TEST(constant_folding, with_phi) {
 
     auto it = irlist->block->instructions.begin();
 
-    ASSERT_EQ(it->var.gvn, 2);
-    ASSERT_EQ(it->var.name, "x");
+    EXPECT_EQ(it->var.gvn, 1);
+    EXPECT_EQ(it->var.name, "x");
 
     const auto & num_obj = *(it);
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*num_obj.obj_ptr));
     const auto & num = std::get<MIR::Number>(*num_obj.obj_ptr);
-    ASSERT_EQ(num.value, 9);
+    EXPECT_EQ(num.value, 9);
 
     // This was the Phi
     const auto & phi_obj = *(++it);
-    ASSERT_EQ(it->var.name, "x");
-    ASSERT_EQ(it->var.gvn, 3);
+    EXPECT_EQ(it->var.name, "x");
+    EXPECT_EQ(it->var.gvn, 3);
 
     ASSERT_TRUE(std::holds_alternative<MIR::Identifier>(*phi_obj.obj_ptr));
     const auto & phi = std::get<MIR::Identifier>(*phi_obj.obj_ptr);
-    ASSERT_EQ(phi.value, "x");
-    ASSERT_EQ(phi.version, 2);
+    EXPECT_EQ(phi.value, "x");
+    EXPECT_EQ(phi.version, 1);
 
     {
         const auto & id_obj = *(++it);
-        ASSERT_EQ(it->var.name, "y");
-        ASSERT_EQ(it->var.gvn, 1);
+        EXPECT_EQ(it->var.name, "y");
+        EXPECT_EQ(it->var.gvn, 1);
 
         ASSERT_TRUE(std::holds_alternative<MIR::Identifier>(*id_obj.obj_ptr));
         const auto & id = std::get<MIR::Identifier>(*id_obj.obj_ptr);
-        ASSERT_EQ(id.value, "x");
-        ASSERT_EQ(id.version, 2);
+        EXPECT_EQ(id.value, "x");
+        EXPECT_EQ(id.version, 1);
     }
 
     {
         const auto & func_obj = *(++it);
         ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
         const auto & func = std::get<MIR::FunctionCall>(*func_obj.obj_ptr);
-        ASSERT_EQ(func.pos_args.size(), 1);
+        EXPECT_EQ(func.pos_args.size(), 1);
 
         const auto & arg_obj = func.pos_args.front();
-        ASSERT_TRUE(std::holds_alternative<MIR::Identifier>(*arg_obj.obj_ptr));
+        EXPECT_TRUE(std::holds_alternative<MIR::Identifier>(*arg_obj.obj_ptr));
         const auto & id = std::get<MIR::Identifier>(*arg_obj.obj_ptr);
-        ASSERT_EQ(id.value, "x");
-        ASSERT_EQ(id.version, 2);
+        EXPECT_EQ(id.value, "x");
+        EXPECT_EQ(id.version, 1);
     }
 }
 

--- a/src/mir/passes/tests/const_folding_test.cpp
+++ b/src/mir/passes/tests/const_folding_test.cpp
@@ -18,10 +18,10 @@ TEST(constant_folding, simple) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
-                                           MIR::Passes::GlobalValueNumbering{},
-                                           MIR::Passes::ConstantFolding{},
-                                       });
+    MIR::Passes::graph_walker(irlist, {
+                                          MIR::Passes::GlobalValueNumbering{},
+                                          MIR::Passes::ConstantFolding{},
+                                      });
 
     ASSERT_EQ(irlist->instructions.size(), 3);
 
@@ -51,15 +51,15 @@ TEST(constant_folding, with_phi) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(irlist, {
-                                           MIR::Passes::GlobalValueNumbering{},
-                                       });
-    MIR::Passes::block_walker(irlist, {
-                                           MIR::Passes::branch_pruning,
-                                           MIR::Passes::join_blocks,
-                                           MIR::Passes::fixup_phis,
-                                           MIR::Passes::ConstantFolding{},
-                                       });
+    MIR::Passes::graph_walker(irlist, {
+                                          MIR::Passes::GlobalValueNumbering{},
+                                      });
+    MIR::Passes::graph_walker(irlist, {
+                                          MIR::Passes::branch_pruning,
+                                          MIR::Passes::join_blocks,
+                                          MIR::Passes::fixup_phis,
+                                          MIR::Passes::ConstantFolding{},
+                                      });
 
     auto it = irlist->instructions.begin();
 
@@ -117,10 +117,10 @@ TEST(constant_folding, three_statements) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
-                                           MIR::Passes::GlobalValueNumbering{},
-                                           MIR::Passes::ConstantFolding{},
-                                       });
+    MIR::Passes::graph_walker(irlist, {
+                                          MIR::Passes::GlobalValueNumbering{},
+                                          MIR::Passes::ConstantFolding{},
+                                      });
 
     const auto & func_obj = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
@@ -145,10 +145,10 @@ TEST(constant_folding, redefined_value) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
-                                           MIR::Passes::GlobalValueNumbering{},
-                                           MIR::Passes::ConstantFolding{},
-                                       });
+    MIR::Passes::graph_walker(irlist, {
+                                          MIR::Passes::GlobalValueNumbering{},
+                                          MIR::Passes::ConstantFolding{},
+                                      });
 
     const auto & func_obj = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
@@ -172,10 +172,10 @@ TEST(constant_folding, in_array) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(irlist, {
-                                           MIR::Passes::GlobalValueNumbering{},
-                                           MIR::Passes::ConstantFolding{},
-                                       });
+    MIR::Passes::graph_walker(irlist, {
+                                          MIR::Passes::GlobalValueNumbering{},
+                                          MIR::Passes::ConstantFolding{},
+                                      });
 
     auto it = irlist->instructions.begin();
     {

--- a/src/mir/passes/tests/constant_propogation_test.cpp
+++ b/src/mir/passes/tests/constant_propogation_test.cpp
@@ -21,7 +21,7 @@ TEST(constant_propogation, phi_should_not_propogate) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                           MIR::Passes::ConstantFolding{},
                                           MIR::Passes::ConstantPropagation{},
@@ -59,7 +59,7 @@ TEST(constant_propogation, function_arguments) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
@@ -92,7 +92,7 @@ TEST(constant_propogation, array) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
@@ -122,12 +122,12 @@ TEST(constant_propogation, method_holder) {
     MIR::Passes::Printer printer{};
 
     bool progress =
-        MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}, std::ref(printer)});
+        MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}, std::ref(printer)});
     ASSERT_TRUE(progress) << "GVN did not make progress";
 
     printer.increment();
     progress =
-        MIR::Passes::block_walker(irlist, {
+        MIR::Passes::graph_walker(irlist, {
                                               [&](std::shared_ptr<MIR::CFGNode> b) {
                                                   return MIR::Passes::threaded_lowering(b, pstate);
                                               },
@@ -136,7 +136,7 @@ TEST(constant_propogation, method_holder) {
     ASSERT_TRUE(progress) << "threaded lowering did not make progress";
 
     printer.increment();
-    progress = MIR::Passes::block_walker(irlist, {
+    progress = MIR::Passes::graph_walker(irlist, {
                                                      MIR::Passes::ConstantFolding{},
                                                      MIR::Passes::ConstantPropagation{},
                                                      std::ref(printer),
@@ -161,13 +161,13 @@ TEST(constant_propogation, into_function_call) {
         )EOF");
     MIR::State::Persistant pstate = make_pstate();
 
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                           [&](std::shared_ptr<MIR::CFGNode> b) {
                                               return MIR::Passes::threaded_lowering(b, pstate);
                                           },
                                       });
-    bool progress = MIR::Passes::block_walker(
+    bool progress = MIR::Passes::graph_walker(
         irlist, {
                     MIR::Passes::ConstantFolding{},
                     MIR::Passes::ConstantPropagation{},

--- a/src/mir/passes/tests/constant_propogation_test.cpp
+++ b/src/mir/passes/tests/constant_propogation_test.cpp
@@ -126,11 +126,13 @@ TEST(constant_propogation, method_holder) {
     ASSERT_TRUE(progress) << "GVN did not make progress";
 
     printer.increment();
-    progress = MIR::Passes::block_walker(
-        irlist, {
-                    [&](std::shared_ptr<MIR::BasicBlock> b) { return MIR::Passes::threaded_lowering(b, pstate); },
-                    std::ref(printer),
-                });
+    progress =
+        MIR::Passes::block_walker(irlist, {
+                                              [&](std::shared_ptr<MIR::CFGNode> b) {
+                                                  return MIR::Passes::threaded_lowering(b, pstate);
+                                              },
+                                              std::ref(printer),
+                                          });
     ASSERT_TRUE(progress) << "threaded lowering did not make progress";
 
     printer.increment();
@@ -161,7 +163,7 @@ TEST(constant_propogation, into_function_call) {
 
     MIR::Passes::block_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
-                                          [&](std::shared_ptr<MIR::BasicBlock> b) {
+                                          [&](std::shared_ptr<MIR::CFGNode> b) {
                                               return MIR::Passes::threaded_lowering(b, pstate);
                                           },
                                       });
@@ -169,7 +171,7 @@ TEST(constant_propogation, into_function_call) {
         irlist, {
                     MIR::Passes::ConstantFolding{},
                     MIR::Passes::ConstantPropagation{},
-                    [&](std::shared_ptr<MIR::BasicBlock> b) {
+                    [&](std::shared_ptr<MIR::CFGNode> b) {
                         return MIR::Passes::lower_program_objects(b, pstate);
                     },
                 });

--- a/src/mir/passes/tests/constant_propogation_test.cpp
+++ b/src/mir/passes/tests/constant_propogation_test.cpp
@@ -29,14 +29,14 @@ TEST(constant_propogation, phi_should_not_propogate) {
 
     const auto & fin = get_bb(get_con(irlist->next)->if_true->next);
 
-    ASSERT_EQ(fin->instructions.size(), 2);
+    ASSERT_EQ(fin->block->instructions.size(), 2);
 
-    const auto & phi_obj = fin->instructions.front();
+    const auto & phi_obj = fin->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Phi>(*phi_obj.obj_ptr));
     ASSERT_EQ(phi_obj.var.name, "x");
     ASSERT_EQ(phi_obj.var.gvn, 3);
 
-    const auto & func_obj = fin->instructions.back();
+    const auto & func_obj = fin->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
     const auto & func = std::get<MIR::FunctionCall>(*func_obj.obj_ptr);
 
@@ -68,9 +68,9 @@ TEST(constant_propogation, function_arguments) {
                                           MIR::Passes::ConstantPropagation{},
                                       });
 
-    ASSERT_EQ(irlist->instructions.size(), 2);
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
 
-    const auto & func_obj = irlist->instructions.back();
+    const auto & func_obj = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*func_obj.obj_ptr));
     const auto & func = std::get<MIR::FunctionCall>(*func_obj.obj_ptr);
 
@@ -101,9 +101,9 @@ TEST(constant_propogation, array) {
                                           MIR::Passes::ConstantPropagation{},
                                       });
 
-    ASSERT_EQ(irlist->instructions.size(), 2);
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
 
-    const auto & func_obj = irlist->instructions.back();
+    const auto & func_obj = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::Array>(*func_obj.obj_ptr));
     const auto & func = std::get<MIR::Array>(*func_obj.obj_ptr);
 
@@ -142,12 +142,12 @@ TEST(constant_propogation, method_holder) {
                                                      std::ref(printer),
                                                  });
     ASSERT_TRUE(progress) << "constant folding/propagation did not make progress";
-    ASSERT_EQ(irlist->instructions.size(), 2);
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
 
-    const auto & front = irlist->instructions.front();
+    const auto & front = irlist->block->instructions.front();
     EXPECT_TRUE(std::holds_alternative<MIR::Program>(*front.obj_ptr));
 
-    const auto & back = irlist->instructions.back();
+    const auto & back = irlist->block->instructions.back();
     EXPECT_TRUE(std::holds_alternative<MIR::FunctionCall>(*back.obj_ptr));
 
     const auto & f = std::get<MIR::FunctionCall>(*back.obj_ptr);
@@ -177,12 +177,12 @@ TEST(constant_propogation, into_function_call) {
                 });
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 2);
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
 
-    const auto & front = irlist->instructions.front();
+    const auto & front = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Program>(*front.obj_ptr));
 
-    const auto & back = irlist->instructions.back();
+    const auto & back = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*back.obj_ptr));
 
     const auto & f = std::get<MIR::FunctionCall>(*back.obj_ptr);

--- a/src/mir/passes/tests/custom_target_program_replacement_test.cpp
+++ b/src/mir/passes/tests/custom_target_program_replacement_test.cpp
@@ -15,9 +15,9 @@ TEST(custom_target_program_replacement, string) {
 
     MIR::Passes::graph_walker(irlist, {MIR::Passes::custom_target_program_replacement});
 
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & fc_obj = irlist->instructions.front();
+    const auto & fc_obj = irlist->block->instructions.front();
     const auto & fc = std::get<MIR::FunctionCall>(*fc_obj.obj_ptr);
 
     const auto & commands_o =
@@ -42,9 +42,9 @@ TEST(custom_target_program_replacement, array) {
 
     MIR::Passes::graph_walker(irlist, {MIR::Passes::custom_target_program_replacement});
 
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & fc_obj = irlist->instructions.front();
+    const auto & fc_obj = irlist->block->instructions.front();
     const auto & fc = std::get<MIR::FunctionCall>(*fc_obj.obj_ptr);
 
     const auto & commands_o =

--- a/src/mir/passes/tests/custom_target_program_replacement_test.cpp
+++ b/src/mir/passes/tests/custom_target_program_replacement_test.cpp
@@ -13,7 +13,7 @@ TEST(custom_target_program_replacement, string) {
         x = custom_target('name', command : 'foo.py')
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {MIR::Passes::custom_target_program_replacement});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::custom_target_program_replacement});
 
     ASSERT_EQ(irlist->instructions.size(), 1);
 
@@ -40,7 +40,7 @@ TEST(custom_target_program_replacement, array) {
         x = custom_target('name', command : ['foo.py', '@INPUT@', '@OUTPUT@'])
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {MIR::Passes::custom_target_program_replacement});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::custom_target_program_replacement});
 
     ASSERT_EQ(irlist->instructions.size(), 1);
 

--- a/src/mir/passes/tests/custom_target_program_replacement_test.cpp
+++ b/src/mir/passes/tests/custom_target_program_replacement_test.cpp
@@ -13,7 +13,7 @@ TEST(custom_target_program_replacement, string) {
         x = custom_target('name', command : 'foo.py')
         )EOF");
 
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::custom_target_program_replacement});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::custom_target_program_replacement});
 
     ASSERT_EQ(irlist->instructions.size(), 1);
 
@@ -40,7 +40,7 @@ TEST(custom_target_program_replacement, array) {
         x = custom_target('name', command : ['foo.py', '@INPUT@', '@OUTPUT@'])
         )EOF");
 
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::custom_target_program_replacement});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::custom_target_program_replacement});
 
     ASSERT_EQ(irlist->instructions.size(), 1);
 

--- a/src/mir/passes/tests/custom_target_program_replacement_test.cpp
+++ b/src/mir/passes/tests/custom_target_program_replacement_test.cpp
@@ -13,11 +13,11 @@ TEST(custom_target_program_replacement, string) {
         x = custom_target('name', command : 'foo.py')
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {MIR::Passes::custom_target_program_replacement});
+    MIR::Passes::block_walker(*irlist, {MIR::Passes::custom_target_program_replacement});
 
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & fc_obj = irlist.instructions.front();
+    const auto & fc_obj = irlist->instructions.front();
     const auto & fc = std::get<MIR::FunctionCall>(*fc_obj.obj_ptr);
 
     const auto & commands_o =
@@ -40,11 +40,11 @@ TEST(custom_target_program_replacement, array) {
         x = custom_target('name', command : ['foo.py', '@INPUT@', '@OUTPUT@'])
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {MIR::Passes::custom_target_program_replacement});
+    MIR::Passes::block_walker(*irlist, {MIR::Passes::custom_target_program_replacement});
 
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & fc_obj = irlist.instructions.front();
+    const auto & fc_obj = irlist->instructions.front();
     const auto & fc = std::get<MIR::FunctionCall>(*fc_obj.obj_ptr);
 
     const auto & commands_o =

--- a/src/mir/passes/tests/dead_code_test.cpp
+++ b/src/mir/passes/tests/dead_code_test.cpp
@@ -18,7 +18,7 @@ TEST(unreachable_code, clear_dead_instructions) {
 
     MIR::State::Persistant pstate = make_pstate();
 
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           [&](std::shared_ptr<MIR::CFGNode> b) {
                                               return MIR::Passes::lower_free_functions(b, pstate);
                                           },
@@ -50,7 +50,7 @@ TEST(unreachable_code, clear_next) {
 
     MIR::State::Persistant pstate = make_pstate();
 
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           [&](std::shared_ptr<MIR::CFGNode> b) {
                                               return MIR::Passes::lower_free_functions(b, pstate);
                                           },

--- a/src/mir/passes/tests/dead_code_test.cpp
+++ b/src/mir/passes/tests/dead_code_test.cpp
@@ -18,8 +18,8 @@ TEST(unreachable_code, clear_dead_instructions) {
 
     MIR::State::Persistant pstate = make_pstate();
 
-    MIR::Passes::block_walker(*irlist, {
-                                          [&](MIR::BasicBlock & b) {
+    MIR::Passes::block_walker(irlist, {
+                                          [&](std::shared_ptr<MIR::BasicBlock> b) {
                                               return MIR::Passes::lower_free_functions(b, pstate);
                                           },
                                           MIR::Passes::delete_unreachable,
@@ -50,8 +50,8 @@ TEST(unreachable_code, clear_next) {
 
     MIR::State::Persistant pstate = make_pstate();
 
-    MIR::Passes::block_walker(*irlist, {
-                                          [&](MIR::BasicBlock & b) {
+    MIR::Passes::block_walker(irlist, {
+                                          [&](std::shared_ptr<MIR::BasicBlock> b) {
                                               return MIR::Passes::lower_free_functions(b, pstate);
                                           },
                                           MIR::Passes::delete_unreachable,

--- a/src/mir/passes/tests/dead_code_test.cpp
+++ b/src/mir/passes/tests/dead_code_test.cpp
@@ -19,7 +19,7 @@ TEST(unreachable_code, clear_dead_instructions) {
     MIR::State::Persistant pstate = make_pstate();
 
     MIR::Passes::block_walker(irlist, {
-                                          [&](std::shared_ptr<MIR::BasicBlock> b) {
+                                          [&](std::shared_ptr<MIR::CFGNode> b) {
                                               return MIR::Passes::lower_free_functions(b, pstate);
                                           },
                                           MIR::Passes::delete_unreachable,
@@ -51,7 +51,7 @@ TEST(unreachable_code, clear_next) {
     MIR::State::Persistant pstate = make_pstate();
 
     MIR::Passes::block_walker(irlist, {
-                                          [&](std::shared_ptr<MIR::BasicBlock> b) {
+                                          [&](std::shared_ptr<MIR::CFGNode> b) {
                                               return MIR::Passes::lower_free_functions(b, pstate);
                                           },
                                           MIR::Passes::delete_unreachable,

--- a/src/mir/passes/tests/dead_code_test.cpp
+++ b/src/mir/passes/tests/dead_code_test.cpp
@@ -25,14 +25,14 @@ TEST(unreachable_code, clear_dead_instructions) {
                                           MIR::Passes::delete_unreachable,
                                       });
 
-    ASSERT_EQ(irlist->instructions.size(), 2);
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
 
-    const auto & msg_obj = irlist->instructions.front();
+    const auto & msg_obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*msg_obj.obj_ptr));
     const auto & msg = std::get<MIR::Message>(*msg_obj.obj_ptr);
     ASSERT_EQ(msg.level, MIR::MessageLevel::MESSAGE);
 
-    const auto & err_obj = irlist->instructions.back();
+    const auto & err_obj = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*err_obj.obj_ptr));
     const auto & err = std::get<MIR::Message>(*err_obj.obj_ptr);
     ASSERT_EQ(err.level, MIR::MessageLevel::ERROR);
@@ -58,7 +58,7 @@ TEST(unreachable_code, clear_next) {
                                       });
 
     const auto & branch = *get_bb(get_con(irlist->next)->if_true);
-    ASSERT_EQ(branch.instructions.size(), 1);
+    ASSERT_EQ(branch.block->instructions.size(), 1);
     ASSERT_TRUE(std::holds_alternative<std::monostate>(branch.next));
 
     const auto & fin = *get_bb(get_bb(get_con(irlist->next)->if_false)->next);

--- a/src/mir/passes/tests/dead_code_test.cpp
+++ b/src/mir/passes/tests/dead_code_test.cpp
@@ -18,21 +18,21 @@ TEST(unreachable_code, clear_dead_instructions) {
 
     MIR::State::Persistant pstate = make_pstate();
 
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::block_walker(*irlist, {
                                           [&](MIR::BasicBlock & b) {
                                               return MIR::Passes::lower_free_functions(b, pstate);
                                           },
                                           MIR::Passes::delete_unreachable,
                                       });
 
-    ASSERT_EQ(irlist.instructions.size(), 2);
+    ASSERT_EQ(irlist->instructions.size(), 2);
 
-    const auto & msg_obj = irlist.instructions.front();
+    const auto & msg_obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*msg_obj.obj_ptr));
     const auto & msg = std::get<MIR::Message>(*msg_obj.obj_ptr);
     ASSERT_EQ(msg.level, MIR::MessageLevel::MESSAGE);
 
-    const auto & err_obj = irlist.instructions.back();
+    const auto & err_obj = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*err_obj.obj_ptr));
     const auto & err = std::get<MIR::Message>(*err_obj.obj_ptr);
     ASSERT_EQ(err.level, MIR::MessageLevel::ERROR);
@@ -50,17 +50,17 @@ TEST(unreachable_code, clear_next) {
 
     MIR::State::Persistant pstate = make_pstate();
 
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::block_walker(*irlist, {
                                           [&](MIR::BasicBlock & b) {
                                               return MIR::Passes::lower_free_functions(b, pstate);
                                           },
                                           MIR::Passes::delete_unreachable,
                                       });
 
-    const auto & branch = *get_bb(get_con(irlist.next)->if_true);
+    const auto & branch = *get_bb(get_con(irlist->next)->if_true);
     ASSERT_EQ(branch.instructions.size(), 1);
     ASSERT_TRUE(std::holds_alternative<std::monostate>(branch.next));
 
-    const auto & fin = *get_bb(get_bb(get_con(irlist.next)->if_false)->next);
+    const auto & fin = *get_bb(get_bb(get_con(irlist->next)->if_false)->next);
     ASSERT_EQ(fin.predecessors.size(), 1);
 }

--- a/src/mir/passes/tests/dead_code_test.cpp
+++ b/src/mir/passes/tests/dead_code_test.cpp
@@ -62,5 +62,5 @@ TEST(unreachable_code, clear_next) {
     ASSERT_TRUE(std::holds_alternative<std::monostate>(branch.next));
 
     const auto & fin = *get_bb(get_bb(get_con(irlist.next)->if_false)->next);
-    ASSERT_EQ(fin.parents.size(), 1);
+    ASSERT_EQ(fin.predecessors.size(), 1);
 }

--- a/src/mir/passes/tests/fixup_phis_test.cpp
+++ b/src/mir/passes/tests/fixup_phis_test.cpp
@@ -27,10 +27,10 @@ TEST(fixup_phi, simple) {
                                           MIR::Passes::fixup_phis,
                                       });
 
-    ASSERT_EQ(irlist->instructions.size(), 2);
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
 
     {
-        const auto & id_obj = irlist->instructions.front();
+        const auto & id_obj = irlist->block->instructions.front();
         ASSERT_EQ(id_obj.var.name, "x");
         ASSERT_EQ(id_obj.var.gvn, 2);
 
@@ -40,7 +40,7 @@ TEST(fixup_phi, simple) {
     }
 
     {
-        const auto & id_obj = irlist->instructions.back();
+        const auto & id_obj = irlist->block->instructions.back();
         ASSERT_EQ(id_obj.var.name, "x");
         ASSERT_EQ(id_obj.var.gvn, 3);
 
@@ -69,9 +69,9 @@ TEST(fixup_phi, three_branches) {
                                           MIR::Passes::fixup_phis,
                                       });
 
-    ASSERT_EQ(irlist->instructions.size(), 3);
+    ASSERT_EQ(irlist->block->instructions.size(), 3);
 
-    auto it = irlist->instructions.begin();
+    auto it = irlist->block->instructions.begin();
 
     {
         const auto & id_obj = *it;
@@ -128,8 +128,8 @@ TEST(fixup_phi, nested_branches) {
     }
 
     ASSERT_TRUE(std::holds_alternative<std::monostate>(irlist->next));
-    ASSERT_EQ(irlist->instructions.size(), 4);
-    auto it = irlist->instructions.begin();
+    ASSERT_EQ(irlist->block->instructions.size(), 4);
+    auto it = irlist->block->instructions.begin();
 
     {
         const auto & id_obj = *it;

--- a/src/mir/passes/tests/fixup_phis_test.cpp
+++ b/src/mir/passes/tests/fixup_phis_test.cpp
@@ -20,8 +20,8 @@ TEST(fixup_phi, simple) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
                                           MIR::Passes::fixup_phis,
@@ -62,8 +62,8 @@ TEST(fixup_phi, three_branches) {
         )EOF");
     std::unordered_map<std::string, uint32_t> data{};
 
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
                                           MIR::Passes::fixup_phis,
@@ -119,7 +119,7 @@ TEST(fixup_phi, nested_branches) {
 
     bool progress = true;
     while (progress) {
-        progress = MIR::Passes::block_walker(irlist, {
+        progress = MIR::Passes::graph_walker(irlist, {
                                                          MIR::Passes::GlobalValueNumbering{},
                                                          MIR::Passes::branch_pruning,
                                                          MIR::Passes::join_blocks,

--- a/src/mir/passes/tests/fixup_phis_test.cpp
+++ b/src/mir/passes/tests/fixup_phis_test.cpp
@@ -20,17 +20,17 @@ TEST(fixup_phi, simple) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(*irlist, {
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
                                           MIR::Passes::fixup_phis,
                                       });
 
-    ASSERT_EQ(irlist.instructions.size(), 2);
+    ASSERT_EQ(irlist->instructions.size(), 2);
 
     {
-        const auto & id_obj = irlist.instructions.front();
+        const auto & id_obj = irlist->instructions.front();
         ASSERT_EQ(id_obj.var.name, "x");
         ASSERT_EQ(id_obj.var.gvn, 2);
 
@@ -40,7 +40,7 @@ TEST(fixup_phi, simple) {
     }
 
     {
-        const auto & id_obj = irlist.instructions.back();
+        const auto & id_obj = irlist->instructions.back();
         ASSERT_EQ(id_obj.var.name, "x");
         ASSERT_EQ(id_obj.var.gvn, 3);
 
@@ -62,16 +62,16 @@ TEST(fixup_phi, three_branches) {
         )EOF");
     std::unordered_map<std::string, uint32_t> data{};
 
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(*irlist, {
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
                                           MIR::Passes::fixup_phis,
                                       });
 
-    ASSERT_EQ(irlist.instructions.size(), 3);
+    ASSERT_EQ(irlist->instructions.size(), 3);
 
-    auto it = irlist.instructions.begin();
+    auto it = irlist->instructions.begin();
 
     {
         const auto & id_obj = *it;
@@ -119,7 +119,7 @@ TEST(fixup_phi, nested_branches) {
 
     bool progress = true;
     while (progress) {
-        progress = MIR::Passes::block_walker(irlist, {
+        progress = MIR::Passes::block_walker(*irlist, {
                                                          MIR::Passes::GlobalValueNumbering{},
                                                          MIR::Passes::branch_pruning,
                                                          MIR::Passes::join_blocks,
@@ -127,9 +127,9 @@ TEST(fixup_phi, nested_branches) {
                                                      });
     }
 
-    ASSERT_TRUE(std::holds_alternative<std::monostate>(irlist.next));
-    ASSERT_EQ(irlist.instructions.size(), 4);
-    auto it = irlist.instructions.begin();
+    ASSERT_TRUE(std::holds_alternative<std::monostate>(irlist->next));
+    ASSERT_EQ(irlist->instructions.size(), 4);
+    auto it = irlist->instructions.begin();
 
     {
         const auto & id_obj = *it;

--- a/src/mir/passes/tests/fixup_phis_test.cpp
+++ b/src/mir/passes/tests/fixup_phis_test.cpp
@@ -31,22 +31,22 @@ TEST(fixup_phi, simple) {
 
     {
         const auto & id_obj = irlist->block->instructions.front();
-        ASSERT_EQ(id_obj.var.name, "x");
-        ASSERT_EQ(id_obj.var.gvn, 2);
+        EXPECT_EQ(id_obj.var.name, "x");
+        EXPECT_EQ(id_obj.var.gvn, 1);
 
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*id_obj.obj_ptr));
         const auto & id = std::get<MIR::Number>(*id_obj.obj_ptr);
-        ASSERT_EQ(id.value, 9);
+        EXPECT_EQ(id.value, 9);
     }
 
     {
         const auto & id_obj = irlist->block->instructions.back();
-        ASSERT_EQ(id_obj.var.name, "x");
-        ASSERT_EQ(id_obj.var.gvn, 3);
+        EXPECT_EQ(id_obj.var.name, "x");
+        EXPECT_EQ(id_obj.var.gvn, 3);
 
         ASSERT_TRUE(std::holds_alternative<MIR::Identifier>(*id_obj.obj_ptr));
         const auto & id = std::get<MIR::Identifier>(*id_obj.obj_ptr);
-        ASSERT_EQ(id.version, 2);
+        EXPECT_EQ(id.version, 1);
     }
 }
 
@@ -76,7 +76,7 @@ TEST(fixup_phi, three_branches) {
     {
         const auto & id_obj = *it;
         EXPECT_EQ(id_obj.var.name, "x");
-        EXPECT_EQ(id_obj.var.gvn, 3);
+        EXPECT_EQ(id_obj.var.gvn, 1);
 
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*id_obj.obj_ptr));
         const auto & id = std::get<MIR::Number>(*id_obj.obj_ptr);
@@ -90,7 +90,7 @@ TEST(fixup_phi, three_branches) {
 
         ASSERT_TRUE(std::holds_alternative<MIR::Identifier>(*id_obj.obj_ptr));
         const auto & id = std::get<MIR::Identifier>(*id_obj.obj_ptr);
-        EXPECT_EQ(id.version, 3);
+        EXPECT_EQ(id.version, 1);
     }
 
     {
@@ -118,62 +118,63 @@ TEST(fixup_phi, nested_branches) {
     std::unordered_map<std::string, uint32_t> data{};
 
     bool progress = true;
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+
     while (progress) {
         progress = MIR::Passes::graph_walker(irlist, {
-                                                         MIR::Passes::GlobalValueNumbering{},
                                                          MIR::Passes::branch_pruning,
                                                          MIR::Passes::join_blocks,
                                                          MIR::Passes::fixup_phis,
                                                      });
     }
 
-    ASSERT_TRUE(std::holds_alternative<std::monostate>(irlist->next));
+    ASSERT_TRUE(irlist->successors.empty());
     ASSERT_EQ(irlist->block->instructions.size(), 4);
     auto it = irlist->block->instructions.begin();
 
     {
         const auto & id_obj = *it;
-        ASSERT_EQ(id_obj.var.name, "x");
-        ASSERT_EQ(id_obj.var.gvn, 1);
+        EXPECT_EQ(id_obj.var.name, "x");
+        EXPECT_EQ(id_obj.var.gvn, 1);
 
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*id_obj.obj_ptr));
         const auto & id = std::get<MIR::Number>(*id_obj.obj_ptr);
-        ASSERT_EQ(id.value, 9);
+        EXPECT_EQ(id.value, 9);
     }
 
     ++it;
 
     {
         const auto & id_obj = *it;
-        ASSERT_EQ(id_obj.var.name, "x");
-        ASSERT_EQ(id_obj.var.gvn, 3);
+        EXPECT_EQ(id_obj.var.name, "x");
+        EXPECT_EQ(id_obj.var.gvn, 2);
 
         ASSERT_TRUE(std::holds_alternative<MIR::Number>(*id_obj.obj_ptr));
         const auto & id = std::get<MIR::Number>(*id_obj.obj_ptr);
-        ASSERT_EQ(id.value, 11);
+        EXPECT_EQ(id.value, 11);
     }
 
     ++it;
 
     {
         const auto & id_obj = *it;
-        ASSERT_EQ(id_obj.var.name, "x");
-        ASSERT_EQ(id_obj.var.gvn, 4);
+        EXPECT_EQ(id_obj.var.name, "x");
+        EXPECT_EQ(id_obj.var.gvn, 4);
 
         ASSERT_TRUE(std::holds_alternative<MIR::Identifier>(*id_obj.obj_ptr));
         const auto & id = std::get<MIR::Identifier>(*id_obj.obj_ptr);
-        ASSERT_EQ(id.version, 3);
+        EXPECT_EQ(id.version, 2);
     }
 
     ++it;
 
     {
         const auto & id_obj = *it;
-        ASSERT_EQ(id_obj.var.name, "x");
-        ASSERT_EQ(id_obj.var.gvn, 5);
+        EXPECT_EQ(id_obj.var.name, "x");
+        EXPECT_EQ(id_obj.var.gvn, 5);
 
         ASSERT_TRUE(std::holds_alternative<MIR::Identifier>(*id_obj.obj_ptr));
         const auto & id = std::get<MIR::Identifier>(*id_obj.obj_ptr);
-        ASSERT_EQ(id.version, 4);
+        EXPECT_EQ(id.version, 4);
     }
 }

--- a/src/mir/passes/tests/fixup_phis_test.cpp
+++ b/src/mir/passes/tests/fixup_phis_test.cpp
@@ -20,8 +20,8 @@ TEST(fixup_phi, simple) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
                                           MIR::Passes::fixup_phis,
@@ -62,8 +62,8 @@ TEST(fixup_phi, three_branches) {
         )EOF");
     std::unordered_map<std::string, uint32_t> data{};
 
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
                                           MIR::Passes::fixup_phis,
@@ -119,7 +119,7 @@ TEST(fixup_phi, nested_branches) {
 
     bool progress = true;
     while (progress) {
-        progress = MIR::Passes::block_walker(*irlist, {
+        progress = MIR::Passes::block_walker(irlist, {
                                                          MIR::Passes::GlobalValueNumbering{},
                                                          MIR::Passes::branch_pruning,
                                                          MIR::Passes::join_blocks,

--- a/src/mir/passes/tests/fixup_phis_test.cpp
+++ b/src/mir/passes/tests/fixup_phis_test.cpp
@@ -54,7 +54,7 @@ TEST(fixup_phi, three_branches) {
     auto irlist = lower(R"EOF(
         if true
             x = 9
-        elif y
+        elif y()
             x = 11
         else
             x = 10

--- a/src/mir/passes/tests/flatten_test.cpp
+++ b/src/mir/passes/tests/flatten_test.cpp
@@ -12,12 +12,12 @@
 TEST(flatten, basic) {
     auto irlist = lower("func(['a', ['b', ['c']], 'd'])");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::flatten(irlist, pstate);
+    bool progress = MIR::Passes::flatten(*irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);
@@ -34,12 +34,12 @@ TEST(flatten, basic) {
 TEST(flatten, already_flat) {
     auto irlist = lower("func(['a', 'd'])");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::flatten(irlist, pstate);
+    bool progress = MIR::Passes::flatten(*irlist, pstate);
 
     ASSERT_FALSE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);
@@ -56,12 +56,12 @@ TEST(flatten, already_flat) {
 TEST(flatten, mixed_args) {
     auto irlist = lower("project('foo', ['a', ['d']])");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::flatten(irlist, pstate);
+    bool progress = MIR::Passes::flatten(*irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);
@@ -77,12 +77,12 @@ TEST(flatten, mixed_args) {
 TEST(flatten, keyword_mixed) {
     auto irlist = lower("func(arg : ['foo', ['bar', ['foobar']]])");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::flatten(irlist, pstate);
+    bool progress = MIR::Passes::flatten(*irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);

--- a/src/mir/passes/tests/flatten_test.cpp
+++ b/src/mir/passes/tests/flatten_test.cpp
@@ -12,7 +12,7 @@
 TEST(flatten, basic) {
     auto irlist = lower("func(['a', ['b', ['c']], 'd'])");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::flatten(*irlist, pstate);
+    bool progress = MIR::Passes::flatten(irlist, pstate);
 
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
@@ -34,7 +34,7 @@ TEST(flatten, basic) {
 TEST(flatten, already_flat) {
     auto irlist = lower("func(['a', 'd'])");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::flatten(*irlist, pstate);
+    bool progress = MIR::Passes::flatten(irlist, pstate);
 
     ASSERT_FALSE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
@@ -56,7 +56,7 @@ TEST(flatten, already_flat) {
 TEST(flatten, mixed_args) {
     auto irlist = lower("project('foo', ['a', ['d']])");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::flatten(*irlist, pstate);
+    bool progress = MIR::Passes::flatten(irlist, pstate);
 
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
@@ -77,7 +77,7 @@ TEST(flatten, mixed_args) {
 TEST(flatten, keyword_mixed) {
     auto irlist = lower("func(arg : ['foo', ['bar', ['foobar']]])");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::flatten(*irlist, pstate);
+    bool progress = MIR::Passes::flatten(irlist, pstate);
 
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);

--- a/src/mir/passes/tests/flatten_test.cpp
+++ b/src/mir/passes/tests/flatten_test.cpp
@@ -15,9 +15,9 @@ TEST(flatten, basic) {
     bool progress = MIR::Passes::flatten(irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);
@@ -37,9 +37,9 @@ TEST(flatten, already_flat) {
     bool progress = MIR::Passes::flatten(irlist, pstate);
 
     ASSERT_FALSE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);
@@ -59,9 +59,9 @@ TEST(flatten, mixed_args) {
     bool progress = MIR::Passes::flatten(irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);
@@ -80,9 +80,9 @@ TEST(flatten, keyword_mixed) {
     bool progress = MIR::Passes::flatten(irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);

--- a/src/mir/passes/tests/free_functions_test.cpp
+++ b/src/mir/passes/tests/free_functions_test.cpp
@@ -20,9 +20,9 @@ TEST(files, simple) {
 
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Array>(*r.obj_ptr));
 
     const auto & a = std::get<MIR::Array>(*r.obj_ptr).value;
@@ -44,9 +44,9 @@ TEST(executable, simple) {
 
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Executable>(*r.obj_ptr));
 
     const auto & e = std::get<MIR::Executable>(*r.obj_ptr);
@@ -71,9 +71,9 @@ TEST(static_library, simple) {
 
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::StaticLibrary>(*r.obj_ptr));
 
     const auto & e = std::get<MIR::StaticLibrary>(*r.obj_ptr);
@@ -109,9 +109,9 @@ TEST(messages, simple) {
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Message>(*r.obj_ptr);
@@ -125,9 +125,9 @@ TEST(messages, two_args) {
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Message>(*r.obj_ptr);
@@ -141,9 +141,9 @@ TEST(assert, simple) {
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Message>(*r.obj_ptr);
@@ -174,9 +174,9 @@ TEST(find_program, found) {
                 });
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 2);
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
 
-    const auto & r = irlist->instructions.back();
+    const auto & r = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Boolean>(*r.obj_ptr);
@@ -188,9 +188,9 @@ TEST(not, simple) {
     const MIR::State::Persistant pstate = make_pstate();
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.back();
+    const auto & r = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Boolean>(*r.obj_ptr);
@@ -202,9 +202,9 @@ TEST(neg, simple) {
     const MIR::State::Persistant pstate = make_pstate();
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.back();
+    const auto & r = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Number>(*r.obj_ptr);
@@ -219,9 +219,9 @@ TEST(custom_target, simple) {
 
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::CustomTarget>(*r.obj_ptr));
 
     const auto & ct = std::get<MIR::CustomTarget>(*r.obj_ptr);
@@ -235,7 +235,7 @@ static inline bool test_equality(const std::string & expr) {
     const MIR::State::Persistant pstate = make_pstate();
 
     MIR::Passes::lower_free_functions(irlist, pstate);
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     const auto & value = std::get<MIR::Boolean>(*r.obj_ptr);
     return value.value;
 }
@@ -262,9 +262,9 @@ TEST(version_compare, simple) {
 
     bool progress = MIR::Passes::lower_string_objects(irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*r.obj_ptr));
 
     const auto & ct = std::get<MIR::Boolean>(*r.obj_ptr);
@@ -281,9 +281,9 @@ TEST(declare_dependency, string_include_dirs) {
 
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Dependency>(*r.obj_ptr));
 
     const auto & d = std::get<MIR::Dependency>(*r.obj_ptr);
@@ -301,9 +301,9 @@ TEST(declare_dependency, compile_args) {
 
     bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Dependency>(*r.obj_ptr));
 
     const auto & d = std::get<MIR::Dependency>(*r.obj_ptr);
@@ -325,9 +325,9 @@ TEST(declare_dependency, recursive) {
     while (progress) {
         progress = MIR::Passes::lower_free_functions(irlist, pstate);
     }
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & r = irlist->instructions.front();
+    const auto & r = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Dependency>(*r.obj_ptr));
 
     const auto & d = std::get<MIR::Dependency>(*r.obj_ptr);
@@ -347,7 +347,7 @@ TEST(add_project_arguments, simple) {
     const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
 
-    const auto & ir = irlist->instructions.front();
+    const auto & ir = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -374,7 +374,7 @@ TEST(add_project_link_arguments, simple) {
     const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
 
-    const auto & ir = irlist->instructions.front();
+    const auto & ir = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -401,7 +401,7 @@ TEST(add_global_arguments, simple) {
     const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
 
-    const auto & ir = irlist->instructions.front();
+    const auto & ir = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -428,7 +428,7 @@ TEST(add_global_link_arguments, simple) {
     const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
     ASSERT_TRUE(progress);
 
-    const auto & ir = irlist->instructions.front();
+    const auto & ir = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -471,8 +471,8 @@ TEST(add_global_link_arguments, combine) {
         ASSERT_TRUE(progress);
     }
 
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & ir = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & ir = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -522,8 +522,8 @@ TEST(add_global_link_arguments, combine_complex) {
         ASSERT_TRUE(progress);
     }
 
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & ir = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & ir = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -573,5 +573,5 @@ TEST(add_global_link_arguments, dont_combine) {
         EXPECT_FALSE(progress);
     }
 
-    ASSERT_EQ(irlist->instructions.size(), 2);
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
 }

--- a/src/mir/passes/tests/free_functions_test.cpp
+++ b/src/mir/passes/tests/free_functions_test.cpp
@@ -158,13 +158,13 @@ TEST(find_program, found) {
     )EOF");
     MIR::State::Persistant pstate = make_pstate();
 
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                           [&](std::shared_ptr<MIR::CFGNode> b) {
                                               return MIR::Passes::threaded_lowering(b, pstate);
                                           },
                                       });
-    bool progress = MIR::Passes::block_walker(
+    bool progress = MIR::Passes::graph_walker(
         irlist, {
                     MIR::Passes::ConstantFolding{},
                     MIR::Passes::ConstantPropagation{},

--- a/src/mir/passes/tests/free_functions_test.cpp
+++ b/src/mir/passes/tests/free_functions_test.cpp
@@ -18,11 +18,11 @@ TEST(files, simple) {
 
     const MIR::State::Persistant pstate = make_pstate();
 
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Array>(*r.obj_ptr));
 
     const auto & a = std::get<MIR::Array>(*r.obj_ptr).value;
@@ -42,11 +42,11 @@ TEST(executable, simple) {
         std::make_shared<MIR::Toolchain::Toolchain>(MIR::Toolchain::get_toolchain(
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Executable>(*r.obj_ptr));
 
     const auto & e = std::get<MIR::Executable>(*r.obj_ptr);
@@ -69,11 +69,11 @@ TEST(static_library, simple) {
         std::make_shared<MIR::Toolchain::Toolchain>(MIR::Toolchain::get_toolchain(
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::StaticLibrary>(*r.obj_ptr));
 
     const auto & e = std::get<MIR::StaticLibrary>(*r.obj_ptr);
@@ -91,14 +91,14 @@ TEST(static_library, simple) {
 TEST(project, valid) {
     auto irlist = lower("project('foo')");
     MIR::State::Persistant pstate = make_pstate();
-    MIR::Passes::lower_project(irlist, pstate);
+    MIR::Passes::lower_project(*irlist, pstate);
     ASSERT_EQ(pstate.name, "foo");
 }
 
 TEST(project, vararg_array) {
     auto irlist = lower("project('foo', ['cpp'])");
     MIR::State::Persistant pstate = make_pstate();
-    MIR::Passes::lower_project(irlist, pstate);
+    MIR::Passes::lower_project(*irlist, pstate);
     ASSERT_EQ(pstate.name, "foo");
     ASSERT_TRUE(pstate.toolchains.find(MIR::Toolchain::Language::CPP) != pstate.toolchains.end());
 }
@@ -106,12 +106,12 @@ TEST(project, vararg_array) {
 TEST(messages, simple) {
     auto irlist = lower("message('foo')");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Message>(*r.obj_ptr);
@@ -122,12 +122,12 @@ TEST(messages, simple) {
 TEST(messages, two_args) {
     auto irlist = lower("warning('foo', 'bar')");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Message>(*r.obj_ptr);
@@ -138,12 +138,12 @@ TEST(messages, two_args) {
 TEST(assert, simple) {
     auto irlist = lower("assert(false)");
     MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Message>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Message>(*r.obj_ptr);
@@ -159,12 +159,12 @@ TEST(find_program, found) {
     MIR::State::Persistant pstate = make_pstate();
 
     MIR::Passes::block_walker(
-        irlist, {
+        *irlist, {
                     MIR::Passes::GlobalValueNumbering{},
                     [&](MIR::BasicBlock & b) { return MIR::Passes::threaded_lowering(b, pstate); },
                 });
     bool progress = MIR::Passes::block_walker(
-        irlist,
+        *irlist,
         {
             MIR::Passes::ConstantFolding{},
             MIR::Passes::ConstantPropagation{},
@@ -172,9 +172,9 @@ TEST(find_program, found) {
         });
 
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 2);
+    ASSERT_EQ(irlist->instructions.size(), 2);
 
-    const auto & r = irlist.instructions.back();
+    const auto & r = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Boolean>(*r.obj_ptr);
@@ -184,11 +184,11 @@ TEST(find_program, found) {
 TEST(not, simple) {
     auto irlist = lower("not false");
     const MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.back();
+    const auto & r = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Boolean>(*r.obj_ptr);
@@ -198,11 +198,11 @@ TEST(not, simple) {
 TEST(neg, simple) {
     auto irlist = lower("-5");
     const MIR::State::Persistant pstate = make_pstate();
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.back();
+    const auto & r = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::Number>(*r.obj_ptr));
 
     const auto & m = std::get<MIR::Number>(*r.obj_ptr);
@@ -215,11 +215,11 @@ TEST(custom_target, simple) {
 
     const MIR::State::Persistant pstate = make_pstate();
 
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::CustomTarget>(*r.obj_ptr));
 
     const auto & ct = std::get<MIR::CustomTarget>(*r.obj_ptr);
@@ -232,8 +232,8 @@ static inline bool test_equality(const std::string & expr) {
 
     const MIR::State::Persistant pstate = make_pstate();
 
-    MIR::Passes::lower_free_functions(irlist, pstate);
-    const auto & r = irlist.instructions.front();
+    MIR::Passes::lower_free_functions(*irlist, pstate);
+    const auto & r = irlist->instructions.front();
     const auto & value = std::get<MIR::Boolean>(*r.obj_ptr);
     return value.value;
 }
@@ -258,11 +258,11 @@ TEST(version_compare, simple) {
 
     MIR::State::Persistant pstate = make_pstate();
 
-    bool progress = MIR::Passes::lower_string_objects(irlist, pstate);
+    bool progress = MIR::Passes::lower_string_objects(*irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Boolean>(*r.obj_ptr));
 
     const auto & ct = std::get<MIR::Boolean>(*r.obj_ptr);
@@ -277,11 +277,11 @@ TEST(declare_dependency, string_include_dirs) {
         std::make_shared<MIR::Toolchain::Toolchain>(MIR::Toolchain::get_toolchain(
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Dependency>(*r.obj_ptr));
 
     const auto & d = std::get<MIR::Dependency>(*r.obj_ptr);
@@ -297,11 +297,11 @@ TEST(declare_dependency, compile_args) {
         std::make_shared<MIR::Toolchain::Toolchain>(MIR::Toolchain::get_toolchain(
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
-    bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Dependency>(*r.obj_ptr));
 
     const auto & d = std::get<MIR::Dependency>(*r.obj_ptr);
@@ -321,11 +321,11 @@ TEST(declare_dependency, recursive) {
 
     bool progress = true;
     while (progress) {
-        progress = MIR::Passes::lower_free_functions(irlist, pstate);
+        progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     }
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & r = irlist.instructions.front();
+    const auto & r = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Dependency>(*r.obj_ptr));
 
     const auto & d = std::get<MIR::Dependency>(*r.obj_ptr);
@@ -342,10 +342,10 @@ TEST(add_project_arguments, simple) {
         std::make_shared<MIR::Toolchain::Toolchain>(MIR::Toolchain::get_toolchain(
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
-    const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    const bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
 
-    const auto & ir = irlist.instructions.front();
+    const auto & ir = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -369,10 +369,10 @@ TEST(add_project_link_arguments, simple) {
         std::make_shared<MIR::Toolchain::Toolchain>(MIR::Toolchain::get_toolchain(
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
-    const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    const bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
 
-    const auto & ir = irlist.instructions.front();
+    const auto & ir = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -396,10 +396,10 @@ TEST(add_global_arguments, simple) {
         std::make_shared<MIR::Toolchain::Toolchain>(MIR::Toolchain::get_toolchain(
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
-    const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    const bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
 
-    const auto & ir = irlist.instructions.front();
+    const auto & ir = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -423,10 +423,10 @@ TEST(add_global_link_arguments, simple) {
         std::make_shared<MIR::Toolchain::Toolchain>(MIR::Toolchain::get_toolchain(
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
-    const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
+    const bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
     ASSERT_TRUE(progress);
 
-    const auto & ir = irlist.instructions.front();
+    const auto & ir = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -454,23 +454,23 @@ TEST(add_global_link_arguments, combine) {
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
     MIR::Passes::Printer printer{};
-    printer(irlist);
+    printer(*irlist);
     printer.increment();
 
     {
-        const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
-        printer(irlist);
+        const bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
+        printer(*irlist);
         printer.increment();
         ASSERT_TRUE(progress);
     }
     {
-        const bool progress = MIR::Passes::combine_add_arguments(irlist);
-        printer(irlist);
+        const bool progress = MIR::Passes::combine_add_arguments(*irlist);
+        printer(*irlist);
         ASSERT_TRUE(progress);
     }
 
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & ir = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & ir = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -505,23 +505,23 @@ TEST(add_global_link_arguments, combine_complex) {
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
     MIR::Passes::Printer printer{};
-    printer(irlist);
+    printer(*irlist);
     printer.increment();
 
     {
-        const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
-        printer(irlist);
+        const bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
+        printer(*irlist);
         printer.increment();
         ASSERT_TRUE(progress);
     }
     {
-        const bool progress = MIR::Passes::combine_add_arguments(irlist);
-        printer(irlist);
+        const bool progress = MIR::Passes::combine_add_arguments(*irlist);
+        printer(*irlist);
         ASSERT_TRUE(progress);
     }
 
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & ir = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & ir = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::AddArguments>(*ir.obj_ptr));
 
     using MIR::Toolchain::Language;
@@ -556,20 +556,20 @@ TEST(add_global_link_arguments, dont_combine) {
             MIR::Toolchain::Language::CPP, MIR::Machines::Machine::BUILD));
 
     MIR::Passes::Printer printer{};
-    printer(irlist);
+    printer(*irlist);
     printer.increment();
 
     {
-        const bool progress = MIR::Passes::lower_free_functions(irlist, pstate);
-        printer(irlist);
+        const bool progress = MIR::Passes::lower_free_functions(*irlist, pstate);
+        printer(*irlist);
         printer.increment();
         EXPECT_TRUE(progress);
     }
     {
-        const bool progress = MIR::Passes::combine_add_arguments(irlist);
-        printer(irlist);
+        const bool progress = MIR::Passes::combine_add_arguments(*irlist);
+        printer(*irlist);
         EXPECT_FALSE(progress);
     }
 
-    ASSERT_EQ(irlist.instructions.size(), 2);
+    ASSERT_EQ(irlist->instructions.size(), 2);
 }

--- a/src/mir/passes/tests/free_functions_test.cpp
+++ b/src/mir/passes/tests/free_functions_test.cpp
@@ -160,7 +160,7 @@ TEST(find_program, found) {
 
     MIR::Passes::block_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
-                                          [&](std::shared_ptr<MIR::BasicBlock> b) {
+                                          [&](std::shared_ptr<MIR::CFGNode> b) {
                                               return MIR::Passes::threaded_lowering(b, pstate);
                                           },
                                       });
@@ -168,7 +168,7 @@ TEST(find_program, found) {
         irlist, {
                     MIR::Passes::ConstantFolding{},
                     MIR::Passes::ConstantPropagation{},
-                    [&](std::shared_ptr<MIR::BasicBlock> b) {
+                    [&](std::shared_ptr<MIR::CFGNode> b) {
                         return MIR::Passes::lower_program_objects(b, pstate);
                     },
                 });

--- a/src/mir/passes/tests/insert_compiler_test.cpp
+++ b/src/mir/passes/tests/insert_compiler_test.cpp
@@ -30,7 +30,7 @@ TEST(insert_compiler, simple) {
         MIR::Machines::PerMachine<std::shared_ptr<MIR::Toolchain::Toolchain>>{tc};
 
     auto irlist = lower("x = meson.get_compiler('cpp')");
-    bool progress = MIR::Passes::insert_compilers(*irlist, tc_map);
+    bool progress = MIR::Passes::insert_compilers(irlist, tc_map);
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
 
@@ -48,7 +48,7 @@ TEST(insert_compiler, unknown_language) {
 
     auto irlist = lower("x = meson.get_compiler('cpp')");
     try {
-        (void)MIR::Passes::insert_compilers(*irlist, tc_map);
+        (void)MIR::Passes::insert_compilers(irlist, tc_map);
         FAIL();
     } catch (Util::Exceptions::MesonException & e) {
         std::string m{e.what()};

--- a/src/mir/passes/tests/insert_compiler_test.cpp
+++ b/src/mir/passes/tests/insert_compiler_test.cpp
@@ -32,9 +32,9 @@ TEST(insert_compiler, simple) {
     auto irlist = lower("x = meson.get_compiler('cpp')");
     bool progress = MIR::Passes::insert_compilers(irlist, tc_map);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & e = irlist->instructions.front();
+    const auto & e = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Compiler>(*e.obj_ptr));
 
     const auto & c = std::get<MIR::Compiler>(*e.obj_ptr);

--- a/src/mir/passes/tests/insert_compiler_test.cpp
+++ b/src/mir/passes/tests/insert_compiler_test.cpp
@@ -30,11 +30,11 @@ TEST(insert_compiler, simple) {
         MIR::Machines::PerMachine<std::shared_ptr<MIR::Toolchain::Toolchain>>{tc};
 
     auto irlist = lower("x = meson.get_compiler('cpp')");
-    bool progress = MIR::Passes::insert_compilers(irlist, tc_map);
+    bool progress = MIR::Passes::insert_compilers(*irlist, tc_map);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & e = irlist.instructions.front();
+    const auto & e = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::Compiler>(*e.obj_ptr));
 
     const auto & c = std::get<MIR::Compiler>(*e.obj_ptr);
@@ -48,7 +48,7 @@ TEST(insert_compiler, unknown_language) {
 
     auto irlist = lower("x = meson.get_compiler('cpp')");
     try {
-        (void)MIR::Passes::insert_compilers(irlist, tc_map);
+        (void)MIR::Passes::insert_compilers(*irlist, tc_map);
         FAIL();
     } catch (Util::Exceptions::MesonException & e) {
         std::string m{e.what()};

--- a/src/mir/passes/tests/insert_phis_test.cpp
+++ b/src/mir/passes/tests/insert_phis_test.cpp
@@ -18,7 +18,7 @@ TEST(insert_phi, simple) {
         endif
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                       });
 
@@ -47,7 +47,7 @@ TEST(insert_phi, three_branches) {
         )EOF");
     std::unordered_map<std::string, uint32_t> data{};
 
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     const auto & fin = get_bb(get_con(irlist->next)->if_true->next);
     ASSERT_EQ(fin->instructions.size(), 2);
@@ -83,7 +83,7 @@ TEST(insert_phi, nested_branches) {
             endif
         endif
         )EOF");
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     {
         const auto & fin =

--- a/src/mir/passes/tests/insert_phis_test.cpp
+++ b/src/mir/passes/tests/insert_phis_test.cpp
@@ -39,7 +39,7 @@ TEST(insert_phi, three_branches) {
     auto irlist = lower(R"EOF(
         if true
             x = 9
-        elif y
+        elif 7
             x = 11
         else
             x = 10

--- a/src/mir/passes/tests/insert_phis_test.cpp
+++ b/src/mir/passes/tests/insert_phis_test.cpp
@@ -23,9 +23,9 @@ TEST(insert_phi, simple) {
                                       });
 
     const auto & fin = get_bb(get_con(irlist->next)->if_false->next);
-    ASSERT_EQ(fin->instructions.size(), 1);
+    ASSERT_EQ(fin->block->instructions.size(), 1);
 
-    MIR::Instruction instr = fin->instructions.front();
+    MIR::Instruction instr = fin->block->instructions.front();
     ASSERT_EQ(instr.var.name, "x");
     ASSERT_EQ(instr.var.gvn, 3); // because value_numbering will run again
 
@@ -50,9 +50,9 @@ TEST(insert_phi, three_branches) {
     MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     const auto & fin = get_bb(get_con(irlist->next)->if_true->next);
-    ASSERT_EQ(fin->instructions.size(), 2);
+    ASSERT_EQ(fin->block->instructions.size(), 2);
 
-    auto it = fin->instructions.begin();
+    auto it = fin->block->instructions.begin();
     EXPECT_EQ(it->var.name, "x");
     EXPECT_EQ(it->var.gvn, 4);
 
@@ -88,8 +88,8 @@ TEST(insert_phi, nested_branches) {
     {
         const auto & fin =
             get_bb(get_bb(get_con(get_bb(get_con(irlist->next)->if_true)->next)->if_true)->next);
-        ASSERT_EQ(fin->instructions.size(), 1);
-        const auto & it = fin->instructions.front();
+        ASSERT_EQ(fin->block->instructions.size(), 1);
+        const auto & it = fin->block->instructions.front();
         ASSERT_EQ(it.var.name, "x");
         ASSERT_EQ(it.var.gvn, 4);
 
@@ -101,8 +101,8 @@ TEST(insert_phi, nested_branches) {
 
     {
         const auto & fin = get_bb(get_con(irlist->next)->if_false);
-        ASSERT_EQ(fin->instructions.size(), 1);
-        const auto & it = fin->instructions.front();
+        ASSERT_EQ(fin->block->instructions.size(), 1);
+        const auto & it = fin->block->instructions.front();
         ASSERT_EQ(it.var.name, "x");
         ASSERT_EQ(it.var.gvn, 5);
 

--- a/src/mir/passes/tests/insert_phis_test.cpp
+++ b/src/mir/passes/tests/insert_phis_test.cpp
@@ -18,7 +18,7 @@ TEST(insert_phi, simple) {
         endif
         )EOF");
 
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                       });
 
@@ -47,7 +47,7 @@ TEST(insert_phi, three_branches) {
         )EOF");
     std::unordered_map<std::string, uint32_t> data{};
 
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     const auto & fin = get_bb(get_con(irlist->next)->if_true->next);
     ASSERT_EQ(fin->instructions.size(), 2);
@@ -83,7 +83,7 @@ TEST(insert_phi, nested_branches) {
             endif
         endif
         )EOF");
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     {
         const auto & fin =

--- a/src/mir/passes/tests/insert_phis_test.cpp
+++ b/src/mir/passes/tests/insert_phis_test.cpp
@@ -18,11 +18,11 @@ TEST(insert_phi, simple) {
         endif
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::block_walker(*irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                       });
 
-    const auto & fin = get_bb(get_con(irlist.next)->if_false->next);
+    const auto & fin = get_bb(get_con(irlist->next)->if_false->next);
     ASSERT_EQ(fin->instructions.size(), 1);
 
     MIR::Instruction instr = fin->instructions.front();
@@ -47,9 +47,9 @@ TEST(insert_phi, three_branches) {
         )EOF");
     std::unordered_map<std::string, uint32_t> data{};
 
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
 
-    const auto & fin = get_bb(get_con(irlist.next)->if_true->next);
+    const auto & fin = get_bb(get_con(irlist->next)->if_true->next);
     ASSERT_EQ(fin->instructions.size(), 2);
 
     auto it = fin->instructions.begin();
@@ -83,11 +83,11 @@ TEST(insert_phi, nested_branches) {
             endif
         endif
         )EOF");
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     {
         const auto & fin =
-            get_bb(get_bb(get_con(get_bb(get_con(irlist.next)->if_true)->next)->if_true)->next);
+            get_bb(get_bb(get_con(get_bb(get_con(irlist->next)->if_true)->next)->if_true)->next);
         ASSERT_EQ(fin->instructions.size(), 1);
         const auto & it = fin->instructions.front();
         ASSERT_EQ(it.var.name, "x");
@@ -100,7 +100,7 @@ TEST(insert_phi, nested_branches) {
     }
 
     {
-        const auto & fin = get_bb(get_con(irlist.next)->if_false);
+        const auto & fin = get_bb(get_con(irlist->next)->if_false);
         ASSERT_EQ(fin->instructions.size(), 1);
         const auto & it = fin->instructions.front();
         ASSERT_EQ(it.var.name, "x");

--- a/src/mir/passes/tests/join_blocks_test.cpp
+++ b/src/mir/passes/tests/join_blocks_test.cpp
@@ -75,12 +75,12 @@ TEST(join_blocks, nested_if_elif_else) {
                                                       });
     ASSERT_TRUE(progress);
 
-    // Check that the parents of the final block are correct
+    // Check that the predecessors of the final block are correct
     const auto & con1 = get_con(irlist.next);
     const auto & bb1 = con1->if_true;
 
     const auto & fin = get_bb(bb1->next);
     ASSERT_EQ(fin->instructions.size(), 2);
-    ASSERT_TRUE(fin->parents.count(bb1.get()));
-    ASSERT_EQ(fin->parents.size(), 2);
+    ASSERT_TRUE(fin->predecessors.count(bb1.get()));
+    ASSERT_EQ(fin->predecessors.size(), 2);
 }

--- a/src/mir/passes/tests/join_blocks_test.cpp
+++ b/src/mir/passes/tests/join_blocks_test.cpp
@@ -13,16 +13,16 @@ TEST(join_blocks, simple) {
     auto irlist = lower("x = 7\nif true\n x = 8\nelse\n x = 9\nendif\ny = x");
     bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
     ASSERT_TRUE(is_bb(irlist->next));
     const auto & next = get_bb(irlist->next);
-    ASSERT_EQ(next->instructions.size(), 1);
+    ASSERT_EQ(next->block->instructions.size(), 1);
 
     progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::join_blocks});
     ASSERT_TRUE(progress);
     ASSERT_TRUE(is_empty(irlist->next));
-    ASSERT_EQ(irlist->instructions.size(), 3);
+    ASSERT_EQ(irlist->block->instructions.size(), 3);
 }
 
 TEST(join_blocks, nested_if) {
@@ -44,7 +44,7 @@ TEST(join_blocks, nested_if) {
                                                      });
     }
     ASSERT_TRUE(std::holds_alternative<std::monostate>(irlist->next));
-    ASSERT_EQ(irlist->instructions.size(), 2);
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
 }
 
 TEST(join_blocks, nested_if_elif_else) {
@@ -80,7 +80,7 @@ TEST(join_blocks, nested_if_elif_else) {
     const auto & bb1 = con1->if_true;
 
     const auto & fin = get_bb(bb1->next);
-    ASSERT_EQ(fin->instructions.size(), 2);
+    ASSERT_EQ(fin->block->instructions.size(), 2);
     ASSERT_TRUE(fin->predecessors.count(bb1));
     ASSERT_EQ(fin->predecessors.size(), 2);
 }

--- a/src/mir/passes/tests/join_blocks_test.cpp
+++ b/src/mir/passes/tests/join_blocks_test.cpp
@@ -11,7 +11,7 @@
 
 TEST(join_blocks, simple) {
     auto irlist = lower("x = 7\nif true\n x = 8\nelse\n x = 9\nendif\ny = x");
-    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
 
@@ -19,7 +19,7 @@ TEST(join_blocks, simple) {
     const auto & next = get_bb(irlist->next);
     ASSERT_EQ(next->instructions.size(), 1);
 
-    progress = MIR::Passes::block_walker(irlist, {MIR::Passes::join_blocks});
+    progress = MIR::Passes::graph_walker(irlist, {MIR::Passes::join_blocks});
     ASSERT_TRUE(progress);
     ASSERT_TRUE(is_empty(irlist->next));
     ASSERT_EQ(irlist->instructions.size(), 3);
@@ -38,7 +38,7 @@ TEST(join_blocks, nested_if) {
         )EOF");
     bool progress = true;
     while (progress) {
-        progress = MIR::Passes::block_walker(irlist, {
+        progress = MIR::Passes::graph_walker(irlist, {
                                                          MIR::Passes::branch_pruning,
                                                          MIR::Passes::join_blocks,
                                                      });
@@ -69,7 +69,7 @@ TEST(join_blocks, nested_if_elif_else) {
         y = x
         z = y
         )EOF");
-    bool progress = MIR::Passes::block_walker(irlist, {
+    bool progress = MIR::Passes::graph_walker(irlist, {
                                                           MIR::Passes::branch_pruning,
                                                           MIR::Passes::join_blocks,
                                                       });

--- a/src/mir/passes/tests/join_blocks_test.cpp
+++ b/src/mir/passes/tests/join_blocks_test.cpp
@@ -11,7 +11,7 @@
 
 TEST(join_blocks, simple) {
     auto irlist = lower("x = 7\nif true\n x = 8\nelse\n x = 9\nendif\ny = x");
-    bool progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::branch_pruning});
+    bool progress = MIR::Passes::block_walker(irlist, {MIR::Passes::branch_pruning});
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
 
@@ -19,7 +19,7 @@ TEST(join_blocks, simple) {
     const auto & next = get_bb(irlist->next);
     ASSERT_EQ(next->instructions.size(), 1);
 
-    progress = MIR::Passes::block_walker(*irlist, {MIR::Passes::join_blocks});
+    progress = MIR::Passes::block_walker(irlist, {MIR::Passes::join_blocks});
     ASSERT_TRUE(progress);
     ASSERT_TRUE(is_empty(irlist->next));
     ASSERT_EQ(irlist->instructions.size(), 3);
@@ -38,7 +38,7 @@ TEST(join_blocks, nested_if) {
         )EOF");
     bool progress = true;
     while (progress) {
-        progress = MIR::Passes::block_walker(*irlist, {
+        progress = MIR::Passes::block_walker(irlist, {
                                                          MIR::Passes::branch_pruning,
                                                          MIR::Passes::join_blocks,
                                                      });
@@ -69,7 +69,7 @@ TEST(join_blocks, nested_if_elif_else) {
         y = x
         z = y
         )EOF");
-    bool progress = MIR::Passes::block_walker(*irlist, {
+    bool progress = MIR::Passes::block_walker(irlist, {
                                                           MIR::Passes::branch_pruning,
                                                           MIR::Passes::join_blocks,
                                                       });
@@ -81,6 +81,6 @@ TEST(join_blocks, nested_if_elif_else) {
 
     const auto & fin = get_bb(bb1->next);
     ASSERT_EQ(fin->instructions.size(), 2);
-    ASSERT_TRUE(fin->predecessors.count(bb1.get()));
+    ASSERT_TRUE(fin->predecessors.count(bb1));
     ASSERT_EQ(fin->predecessors.size(), 2);
 }

--- a/src/mir/passes/tests/lower_test.cpp
+++ b/src/mir/passes/tests/lower_test.cpp
@@ -11,8 +11,8 @@
 TEST(lower, trivial) {
     auto irlist = lower("project('foo')");
     MIR::State::Persistant pstate = make_pstate();
-    MIR::Passes::lower_project(*irlist, pstate);
-    MIR::lower(*irlist, pstate);
+    MIR::Passes::lower_project(irlist, pstate);
+    MIR::lower(irlist, pstate);
 }
 
 TEST(lower, after_files) {
@@ -25,7 +25,7 @@ TEST(lower, after_files) {
         )EOF");
     MIR::State::Persistant pstate = make_pstate();
     // MIR::Passes::lower_project(irlist, pstate);
-    MIR::lower(*irlist, pstate);
+    MIR::lower(irlist, pstate);
 
     ASSERT_EQ(irlist->instructions.size(), 1);
 

--- a/src/mir/passes/tests/lower_test.cpp
+++ b/src/mir/passes/tests/lower_test.cpp
@@ -11,8 +11,8 @@
 TEST(lower, trivial) {
     auto irlist = lower("project('foo')");
     MIR::State::Persistant pstate = make_pstate();
-    MIR::Passes::lower_project(irlist, pstate);
-    MIR::lower(irlist, pstate);
+    MIR::Passes::lower_project(*irlist, pstate);
+    MIR::lower(*irlist, pstate);
 }
 
 TEST(lower, after_files) {
@@ -25,11 +25,11 @@ TEST(lower, after_files) {
         )EOF");
     MIR::State::Persistant pstate = make_pstate();
     // MIR::Passes::lower_project(irlist, pstate);
-    MIR::lower(irlist, pstate);
+    MIR::lower(*irlist, pstate);
 
-    ASSERT_EQ(irlist.instructions.size(), 1);
+    ASSERT_EQ(irlist->instructions.size(), 1);
 
-    const auto & ct_obj = irlist.instructions.front();
+    const auto & ct_obj = irlist->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::CustomTarget>(*ct_obj.obj_ptr));
 }
 

--- a/src/mir/passes/tests/lower_test.cpp
+++ b/src/mir/passes/tests/lower_test.cpp
@@ -27,9 +27,9 @@ TEST(lower, after_files) {
     // MIR::Passes::lower_project(irlist, pstate);
     MIR::lower(irlist, pstate);
 
-    ASSERT_EQ(irlist->instructions.size(), 1);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
-    const auto & ct_obj = irlist->instructions.front();
+    const auto & ct_obj = irlist->block->instructions.front();
     ASSERT_TRUE(std::holds_alternative<MIR::CustomTarget>(*ct_obj.obj_ptr));
 }
 

--- a/src/mir/passes/tests/machine_lower_test.cpp
+++ b/src/mir/passes/tests/machine_lower_test.cpp
@@ -18,10 +18,10 @@ TEST(machine_lower, simple) {
     auto info = MIR::Machines::PerMachine<MIR::Machines::Info>(
         MIR::Machines::Info{MIR::Machines::Machine::BUILD, MIR::Machines::Kernel::LINUX,
                             MIR::Machines::Endian::LITTLE, "x86_64"});
-    bool progress = MIR::Passes::machine_lower(irlist, info);
+    bool progress = MIR::Passes::machine_lower(*irlist, info);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 2);
-    const auto & r = irlist.instructions.back();
+    ASSERT_EQ(irlist->instructions.size(), 2);
+    const auto & r = irlist->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::String>(*r.obj_ptr));
     ASSERT_EQ(std::get<MIR::String>(*r.obj_ptr).value, "x86_64");
 }
@@ -31,10 +31,10 @@ TEST(machine_lower, in_array) {
     auto info = MIR::Machines::PerMachine<MIR::Machines::Info>(
         MIR::Machines::Info{MIR::Machines::Machine::BUILD, MIR::Machines::Kernel::LINUX,
                             MIR::Machines::Endian::LITTLE, "x86_64"});
-    bool progress = MIR::Passes::machine_lower(irlist, info);
+    bool progress = MIR::Passes::machine_lower(*irlist, info);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & r = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & r = irlist->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::Array>(*r.obj_ptr));
     const auto & a = std::get<MIR::Array>(*r.obj_ptr).value;
@@ -49,10 +49,10 @@ TEST(machine_lower, in_function_args) {
     auto info = MIR::Machines::PerMachine<MIR::Machines::Info>(
         MIR::Machines::Info{MIR::Machines::Machine::BUILD, MIR::Machines::Kernel::LINUX,
                             MIR::Machines::Endian::LITTLE, "x86_64"});
-    bool progress = MIR::Passes::machine_lower(irlist, info);
+    bool progress = MIR::Passes::machine_lower(*irlist, info);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 1);
-    const auto & r = irlist.instructions.front();
+    ASSERT_EQ(irlist->instructions.size(), 1);
+    const auto & r = irlist->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);
@@ -67,12 +67,12 @@ TEST(machine_lower, in_condtion) {
     auto info = MIR::Machines::PerMachine<MIR::Machines::Info>(
         MIR::Machines::Info{MIR::Machines::Machine::BUILD, MIR::Machines::Kernel::LINUX,
                             MIR::Machines::Endian::LITTLE, "x86_64"});
-    bool progress = MIR::Passes::machine_lower(irlist, info);
+    bool progress = MIR::Passes::machine_lower(*irlist, info);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist.instructions.size(), 0);
+    ASSERT_EQ(irlist->instructions.size(), 0);
 
-    ASSERT_TRUE(is_con(irlist.next));
-    const auto & con = get_con(irlist.next);
+    ASSERT_TRUE(is_con(irlist->next));
+    const auto & con = get_con(irlist->next);
     const auto & obj = con->condition;
     ASSERT_TRUE(std::holds_alternative<MIR::String>(*obj.obj_ptr));
     ASSERT_EQ(std::get<MIR::String>(*obj.obj_ptr).value, "x86_64");

--- a/src/mir/passes/tests/machine_lower_test.cpp
+++ b/src/mir/passes/tests/machine_lower_test.cpp
@@ -71,9 +71,8 @@ TEST(machine_lower, in_condtion) {
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->block->instructions.size(), 0);
 
-    ASSERT_TRUE(is_con(irlist->next));
-    const auto & con = get_con(irlist->next);
-    const auto & obj = con->condition;
+    const auto & obj = std::get<0>(
+        std::get<MIR::Branch>(*irlist->block->instructions.back().obj_ptr).branches.at(0));
     ASSERT_TRUE(std::holds_alternative<MIR::String>(*obj.obj_ptr));
     ASSERT_EQ(std::get<MIR::String>(*obj.obj_ptr).value, "x86_64");
 }

--- a/src/mir/passes/tests/machine_lower_test.cpp
+++ b/src/mir/passes/tests/machine_lower_test.cpp
@@ -18,7 +18,7 @@ TEST(machine_lower, simple) {
     auto info = MIR::Machines::PerMachine<MIR::Machines::Info>(
         MIR::Machines::Info{MIR::Machines::Machine::BUILD, MIR::Machines::Kernel::LINUX,
                             MIR::Machines::Endian::LITTLE, "x86_64"});
-    bool progress = MIR::Passes::machine_lower(*irlist, info);
+    bool progress = MIR::Passes::machine_lower(irlist, info);
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 2);
     const auto & r = irlist->instructions.back();
@@ -31,7 +31,7 @@ TEST(machine_lower, in_array) {
     auto info = MIR::Machines::PerMachine<MIR::Machines::Info>(
         MIR::Machines::Info{MIR::Machines::Machine::BUILD, MIR::Machines::Kernel::LINUX,
                             MIR::Machines::Endian::LITTLE, "x86_64"});
-    bool progress = MIR::Passes::machine_lower(*irlist, info);
+    bool progress = MIR::Passes::machine_lower(irlist, info);
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
     const auto & r = irlist->instructions.front();
@@ -49,7 +49,7 @@ TEST(machine_lower, in_function_args) {
     auto info = MIR::Machines::PerMachine<MIR::Machines::Info>(
         MIR::Machines::Info{MIR::Machines::Machine::BUILD, MIR::Machines::Kernel::LINUX,
                             MIR::Machines::Endian::LITTLE, "x86_64"});
-    bool progress = MIR::Passes::machine_lower(*irlist, info);
+    bool progress = MIR::Passes::machine_lower(irlist, info);
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 1);
     const auto & r = irlist->instructions.front();
@@ -67,7 +67,7 @@ TEST(machine_lower, in_condtion) {
     auto info = MIR::Machines::PerMachine<MIR::Machines::Info>(
         MIR::Machines::Info{MIR::Machines::Machine::BUILD, MIR::Machines::Kernel::LINUX,
                             MIR::Machines::Endian::LITTLE, "x86_64"});
-    bool progress = MIR::Passes::machine_lower(*irlist, info);
+    bool progress = MIR::Passes::machine_lower(irlist, info);
     ASSERT_TRUE(progress);
     ASSERT_EQ(irlist->instructions.size(), 0);
 

--- a/src/mir/passes/tests/machine_lower_test.cpp
+++ b/src/mir/passes/tests/machine_lower_test.cpp
@@ -62,14 +62,14 @@ TEST(machine_lower, in_function_args) {
     ASSERT_EQ(std::get<MIR::String>(*f.pos_args[0].obj_ptr).value, "little");
 }
 
-TEST(machine_lower, in_condtion) {
+TEST(machine_lower, in_condition) {
     auto irlist = lower("if host_machine.cpu_family()\n x = 2\nendif");
     auto info = MIR::Machines::PerMachine<MIR::Machines::Info>(
         MIR::Machines::Info{MIR::Machines::Machine::BUILD, MIR::Machines::Kernel::LINUX,
                             MIR::Machines::Endian::LITTLE, "x86_64"});
     bool progress = MIR::Passes::machine_lower(irlist, info);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->block->instructions.size(), 0);
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
 
     const auto & obj = std::get<0>(
         std::get<MIR::Branch>(*irlist->block->instructions.back().obj_ptr).branches.at(0));

--- a/src/mir/passes/tests/machine_lower_test.cpp
+++ b/src/mir/passes/tests/machine_lower_test.cpp
@@ -20,8 +20,8 @@ TEST(machine_lower, simple) {
                             MIR::Machines::Endian::LITTLE, "x86_64"});
     bool progress = MIR::Passes::machine_lower(irlist, info);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 2);
-    const auto & r = irlist->instructions.back();
+    ASSERT_EQ(irlist->block->instructions.size(), 2);
+    const auto & r = irlist->block->instructions.back();
     ASSERT_TRUE(std::holds_alternative<MIR::String>(*r.obj_ptr));
     ASSERT_EQ(std::get<MIR::String>(*r.obj_ptr).value, "x86_64");
 }
@@ -33,8 +33,8 @@ TEST(machine_lower, in_array) {
                             MIR::Machines::Endian::LITTLE, "x86_64"});
     bool progress = MIR::Passes::machine_lower(irlist, info);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & r = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & r = irlist->block->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::Array>(*r.obj_ptr));
     const auto & a = std::get<MIR::Array>(*r.obj_ptr).value;
@@ -51,8 +51,8 @@ TEST(machine_lower, in_function_args) {
                             MIR::Machines::Endian::LITTLE, "x86_64"});
     bool progress = MIR::Passes::machine_lower(irlist, info);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 1);
-    const auto & r = irlist->instructions.front();
+    ASSERT_EQ(irlist->block->instructions.size(), 1);
+    const auto & r = irlist->block->instructions.front();
 
     ASSERT_TRUE(std::holds_alternative<MIR::FunctionCall>(*r.obj_ptr));
     const auto & f = std::get<MIR::FunctionCall>(*r.obj_ptr);
@@ -69,7 +69,7 @@ TEST(machine_lower, in_condtion) {
                             MIR::Machines::Endian::LITTLE, "x86_64"});
     bool progress = MIR::Passes::machine_lower(irlist, info);
     ASSERT_TRUE(progress);
-    ASSERT_EQ(irlist->instructions.size(), 0);
+    ASSERT_EQ(irlist->block->instructions.size(), 0);
 
     ASSERT_TRUE(is_con(irlist->next));
     const auto & con = get_con(irlist->next);

--- a/src/mir/passes/tests/test_utils.cpp
+++ b/src/mir/passes/tests/test_utils.cpp
@@ -13,7 +13,7 @@ std::unique_ptr<Frontend::AST::CodeBlock> parse(const std::string & in) {
 std::shared_ptr<MIR::CFGNode> lower(const std::string & in) {
     auto block = parse(in);
     const MIR::State::Persistant pstate = make_pstate();
-    return MIR::lower_ast(block, pstate);
+    return MIR::lower_ast(block, pstate).root;
 }
 
 MIR::State::Persistant make_pstate() { return MIR::State::Persistant{src_root, build_root, ""}; }

--- a/src/mir/passes/tests/test_utils.cpp
+++ b/src/mir/passes/tests/test_utils.cpp
@@ -10,7 +10,7 @@ std::unique_ptr<Frontend::AST::CodeBlock> parse(const std::string & in) {
     return drv.parse(stream);
 }
 
-MIR::BasicBlock lower(const std::string & in) {
+std::shared_ptr<MIR::BasicBlock> lower(const std::string & in) {
     auto block = parse(in);
     const MIR::State::Persistant pstate = make_pstate();
     return MIR::lower_ast(block, pstate);

--- a/src/mir/passes/tests/test_utils.cpp
+++ b/src/mir/passes/tests/test_utils.cpp
@@ -10,7 +10,7 @@ std::unique_ptr<Frontend::AST::CodeBlock> parse(const std::string & in) {
     return drv.parse(stream);
 }
 
-std::shared_ptr<MIR::BasicBlock> lower(const std::string & in) {
+std::shared_ptr<MIR::CFGNode> lower(const std::string & in) {
     auto block = parse(in);
     const MIR::State::Persistant pstate = make_pstate();
     return MIR::lower_ast(block, pstate);

--- a/src/mir/passes/tests/test_utils.hpp
+++ b/src/mir/passes/tests/test_utils.hpp
@@ -20,24 +20,4 @@ std::unique_ptr<Frontend::AST::CodeBlock> parse(const std::string & in);
 
 std::shared_ptr<MIR::CFGNode> lower(const std::string & in);
 
-inline bool is_bb(const MIR::NextType & next) {
-    return std::holds_alternative<std::shared_ptr<MIR::CFGNode>>(next);
-}
-
-inline std::shared_ptr<MIR::CFGNode> get_bb(const MIR::NextType & next) {
-    return std::get<std::shared_ptr<MIR::CFGNode>>(next);
-}
-
-inline bool is_con(const MIR::NextType & next) {
-    return std::holds_alternative<std::unique_ptr<MIR::Condition>>(next);
-}
-
-inline const std::unique_ptr<MIR::Condition> & get_con(const MIR::NextType & next) {
-    return std::get<std::unique_ptr<MIR::Condition>>(next);
-}
-
-inline bool is_empty(const MIR::NextType & next) {
-    return std::holds_alternative<std::monostate>(next);
-}
-
 MIR::State::Persistant make_pstate();

--- a/src/mir/passes/tests/test_utils.hpp
+++ b/src/mir/passes/tests/test_utils.hpp
@@ -18,7 +18,7 @@ static const std::filesystem::path build_root = "/home/test user/src/test projec
 
 std::unique_ptr<Frontend::AST::CodeBlock> parse(const std::string & in);
 
-MIR::BasicBlock lower(const std::string & in);
+std::shared_ptr<MIR::BasicBlock> lower(const std::string & in);
 
 inline bool is_bb(const MIR::NextType & next) {
     return std::holds_alternative<std::shared_ptr<MIR::BasicBlock>>(next);

--- a/src/mir/passes/tests/test_utils.hpp
+++ b/src/mir/passes/tests/test_utils.hpp
@@ -18,14 +18,14 @@ static const std::filesystem::path build_root = "/home/test user/src/test projec
 
 std::unique_ptr<Frontend::AST::CodeBlock> parse(const std::string & in);
 
-std::shared_ptr<MIR::BasicBlock> lower(const std::string & in);
+std::shared_ptr<MIR::CFGNode> lower(const std::string & in);
 
 inline bool is_bb(const MIR::NextType & next) {
-    return std::holds_alternative<std::shared_ptr<MIR::BasicBlock>>(next);
+    return std::holds_alternative<std::shared_ptr<MIR::CFGNode>>(next);
 }
 
-inline std::shared_ptr<MIR::BasicBlock> get_bb(const MIR::NextType & next) {
-    return std::get<std::shared_ptr<MIR::BasicBlock>>(next);
+inline std::shared_ptr<MIR::CFGNode> get_bb(const MIR::NextType & next) {
+    return std::get<std::shared_ptr<MIR::CFGNode>>(next);
 }
 
 inline bool is_con(const MIR::NextType & next) {

--- a/src/mir/passes/tests/value_numbering_test.cpp
+++ b/src/mir/passes/tests/value_numbering_test.cpp
@@ -30,7 +30,7 @@ TEST(value_numbering, branching) {
             x = 10
         endif
         )EOF");
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     ASSERT_EQ(irlist->instructions.front().var.gvn, 1);
     ASSERT_EQ(irlist->instructions.back().var.gvn, 2);
@@ -52,7 +52,7 @@ TEST(value_numbering, three_branch) {
             x = 11
         endif
         )EOF");
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     const auto & bb1 = get_con(irlist->next)->if_true;
     EXPECT_EQ(bb1->instructions.front().var.gvn, 3);
@@ -74,7 +74,7 @@ TEST(number_uses, simple) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                       });
 
@@ -114,10 +114,10 @@ TEST(number_uses, with_phi) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                       });
-    MIR::Passes::block_walker(irlist, {
+    MIR::Passes::graph_walker(irlist, {
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
                                           MIR::Passes::fixup_phis,
@@ -159,7 +159,7 @@ TEST(number_uses, with_phi_no_pruning_in_func_call) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     const auto & fin = get_bb(get_con(irlist->next)->if_false->next);
     ASSERT_EQ(fin->instructions.size(), 2);
@@ -193,7 +193,7 @@ TEST(number_uses, with_phi_no_pruning) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     const auto & fin = get_bb(get_con(irlist->next)->if_false->next);
     ASSERT_EQ(fin->instructions.size(), 2);
@@ -224,7 +224,7 @@ TEST(number_uses, three_statements) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     ASSERT_EQ(irlist->instructions.size(), 3);
 
@@ -249,7 +249,7 @@ TEST(number_uses, redefined_value) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     ASSERT_EQ(irlist->instructions.size(), 3);
 
@@ -274,7 +274,7 @@ TEST(number_uses, in_array) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::graph_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     ASSERT_EQ(irlist->instructions.size(), 3);
 

--- a/src/mir/passes/tests/value_numbering_test.cpp
+++ b/src/mir/passes/tests/value_numbering_test.cpp
@@ -14,7 +14,7 @@ TEST(value_numbering, simple) {
         x = 7
         x = 8
         )EOF");
-    MIR::Passes::GlobalValueNumbering{}(*irlist);
+    MIR::Passes::GlobalValueNumbering{}(irlist);
 
     ASSERT_EQ(irlist->instructions.front().var.gvn, 1);
     ASSERT_EQ(irlist->instructions.back().var.gvn, 2);
@@ -30,7 +30,7 @@ TEST(value_numbering, branching) {
             x = 10
         endif
         )EOF");
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     ASSERT_EQ(irlist->instructions.front().var.gvn, 1);
     ASSERT_EQ(irlist->instructions.back().var.gvn, 2);
@@ -52,7 +52,7 @@ TEST(value_numbering, three_branch) {
             x = 11
         endif
         )EOF");
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     const auto & bb1 = get_con(irlist->next)->if_true;
     EXPECT_EQ(bb1->instructions.front().var.gvn, 3);
@@ -74,7 +74,7 @@ TEST(number_uses, simple) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                       });
 
@@ -114,10 +114,10 @@ TEST(number_uses, with_phi) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                           MIR::Passes::GlobalValueNumbering{},
                                       });
-    MIR::Passes::block_walker(*irlist, {
+    MIR::Passes::block_walker(irlist, {
                                           MIR::Passes::branch_pruning,
                                           MIR::Passes::join_blocks,
                                           MIR::Passes::fixup_phis,
@@ -159,7 +159,7 @@ TEST(number_uses, with_phi_no_pruning_in_func_call) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     const auto & fin = get_bb(get_con(irlist->next)->if_false->next);
     ASSERT_EQ(fin->instructions.size(), 2);
@@ -193,7 +193,7 @@ TEST(number_uses, with_phi_no_pruning) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     const auto & fin = get_bb(get_con(irlist->next)->if_false->next);
     ASSERT_EQ(fin->instructions.size(), 2);
@@ -224,7 +224,7 @@ TEST(number_uses, three_statements) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     ASSERT_EQ(irlist->instructions.size(), 3);
 
@@ -249,7 +249,7 @@ TEST(number_uses, redefined_value) {
 
     // We do this in two walks because we don't have all of passes necissary to
     // get the state we want to test.
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     ASSERT_EQ(irlist->instructions.size(), 3);
 
@@ -274,7 +274,7 @@ TEST(number_uses, in_array) {
 
     // Do this in two passes as otherwise the phi won't get inserted, and thus y will point at the
     // wrong thing
-    MIR::Passes::block_walker(*irlist, {MIR::Passes::GlobalValueNumbering{}});
+    MIR::Passes::block_walker(irlist, {MIR::Passes::GlobalValueNumbering{}});
 
     ASSERT_EQ(irlist->instructions.size(), 3);
 

--- a/src/mir/passes/tests/walker_tests.cpp
+++ b/src/mir/passes/tests/walker_tests.cpp
@@ -12,8 +12,8 @@
 TEST(block_walker, simple) {
     std::unordered_map<uint32_t, uint32_t> seen{};
 
-    auto && tester = [&seen](MIR::BasicBlock & b) -> bool {
-        seen[b.index]++;
+    auto && tester = [&seen](std::shared_ptr<MIR::BasicBlock> b) -> bool {
+        seen[b->index]++;
         return false;
     };
 
@@ -25,7 +25,7 @@ TEST(block_walker, simple) {
         endif
         )EOF");
 
-    MIR::Passes::block_walker(*irlist, {tester});
+    MIR::Passes::block_walker(irlist, {tester});
     for (auto && [block_id, count] : seen) {
         EXPECT_EQ(count, 1) << "block " << block_id << " visited " << count
                             << " times instead of 1";
@@ -35,8 +35,8 @@ TEST(block_walker, simple) {
 TEST(block_walker, predecessors_first) {
     std::vector<uint32_t> seen;
 
-    auto && tester = [&seen](MIR::BasicBlock & b) -> bool {
-        seen.emplace_back(b.index);
+    auto && tester = [&seen](std::shared_ptr<MIR::BasicBlock> b) -> bool {
+        seen.emplace_back(b->index);
         return false;
     };
 
@@ -50,7 +50,7 @@ TEST(block_walker, predecessors_first) {
         a = 3
         )EOF");
 
-    MIR::Passes::block_walker(*irlist, {tester});
+    MIR::Passes::block_walker(irlist, {tester});
     ASSERT_EQ(seen.size(), 4);
     EXPECT_EQ(seen[0], irlist->index);
 

--- a/src/mir/passes/tests/walker_tests.cpp
+++ b/src/mir/passes/tests/walker_tests.cpp
@@ -25,7 +25,7 @@ TEST(block_walker, simple) {
         endif
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {tester});
+    MIR::Passes::block_walker(*irlist, {tester});
     for (auto && [block_id, count] : seen) {
         EXPECT_EQ(count, 1) << "block " << block_id << " visited " << count
                             << " times instead of 1";
@@ -50,11 +50,11 @@ TEST(block_walker, predecessors_first) {
         a = 3
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {tester});
+    MIR::Passes::block_walker(*irlist, {tester});
     ASSERT_EQ(seen.size(), 4);
-    EXPECT_EQ(seen[0], irlist.index);
+    EXPECT_EQ(seen[0], irlist->index);
 
-    auto & con = *std::get<std::unique_ptr<MIR::Condition>>(irlist.next);
+    auto & con = *std::get<std::unique_ptr<MIR::Condition>>(irlist->next);
     auto i = con.if_false.get()->index;
     EXPECT_TRUE(seen[1] == i || seen[2] == i);
     i = con.if_true.get()->index;

--- a/src/mir/passes/tests/walker_tests.cpp
+++ b/src/mir/passes/tests/walker_tests.cpp
@@ -9,7 +9,7 @@
 
 #include <unordered_map>
 
-TEST(block_walker, simple) {
+TEST(graph_walker, simple) {
     std::unordered_map<uint32_t, uint32_t> seen{};
 
     auto && tester = [&seen](std::shared_ptr<MIR::CFGNode> b) -> bool {
@@ -25,14 +25,14 @@ TEST(block_walker, simple) {
         endif
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {tester});
+    MIR::Passes::graph_walker(irlist, {tester});
     for (auto && [block_id, count] : seen) {
         EXPECT_EQ(count, 1) << "block " << block_id << " visited " << count
                             << " times instead of 1";
     }
 }
 
-TEST(block_walker, predecessors_first) {
+TEST(graph_walker, predecessors_first) {
     std::vector<uint32_t> seen;
 
     auto && tester = [&seen](std::shared_ptr<MIR::CFGNode> b) -> bool {
@@ -50,7 +50,7 @@ TEST(block_walker, predecessors_first) {
         a = 3
         )EOF");
 
-    MIR::Passes::block_walker(irlist, {tester});
+    MIR::Passes::graph_walker(irlist, {tester});
     ASSERT_EQ(seen.size(), 4);
     EXPECT_EQ(seen[0], irlist->index);
 

--- a/src/mir/passes/tests/walker_tests.cpp
+++ b/src/mir/passes/tests/walker_tests.cpp
@@ -12,7 +12,7 @@
 TEST(block_walker, simple) {
     std::unordered_map<uint32_t, uint32_t> seen{};
 
-    auto && tester = [&seen](std::shared_ptr<MIR::BasicBlock> b) -> bool {
+    auto && tester = [&seen](std::shared_ptr<MIR::CFGNode> b) -> bool {
         seen[b->index]++;
         return false;
     };
@@ -35,7 +35,7 @@ TEST(block_walker, simple) {
 TEST(block_walker, predecessors_first) {
     std::vector<uint32_t> seen;
 
-    auto && tester = [&seen](std::shared_ptr<MIR::BasicBlock> b) -> bool {
+    auto && tester = [&seen](std::shared_ptr<MIR::CFGNode> b) -> bool {
         seen.emplace_back(b->index);
         return false;
     };
@@ -60,6 +60,6 @@ TEST(block_walker, predecessors_first) {
     i = con.if_true.get()->index;
     EXPECT_TRUE(seen[1] == i || seen[2] == i);
 
-    auto & last = *std::get<std::shared_ptr<MIR::BasicBlock>>(con.if_true.get()->next);
+    auto & last = *std::get<std::shared_ptr<MIR::CFGNode>>(con.if_true.get()->next);
     ASSERT_EQ(seen[3], last.index);
 }

--- a/src/mir/passes/tests/walker_tests.cpp
+++ b/src/mir/passes/tests/walker_tests.cpp
@@ -32,7 +32,7 @@ TEST(block_walker, simple) {
     }
 }
 
-TEST(block_walker, parents_first) {
+TEST(block_walker, predecessors_first) {
     std::vector<uint32_t> seen;
 
     auto && tester = [&seen](MIR::BasicBlock & b) -> bool {

--- a/src/mir/passes/threaded.cpp
+++ b/src/mir/passes/threaded.cpp
@@ -242,21 +242,21 @@ bool threaded_lowering(std::shared_ptr<CFGNode> block, State::Persistant & pstat
     progress |=
         graph_walker(block, {
                                 [&](std::shared_ptr<CFGNode> b) {
-                                    return function_walker(*b, [&](const Instruction & obj) {
+                                    return instruction_walker(*b, {[&](const Instruction & obj) {
                                         return search_threaded(obj, pstate, jobs);
-                                    });
+                                    }});
                                 },
                             });
     if (progress) {
         search_for_threaded_impl(jobs, pstate);
-        progress |=
-            graph_walker(block, {
-                                    [&](std::shared_ptr<CFGNode> b) {
-                                        return function_walker(*b, [&](const Instruction & obj) {
-                                            return replace_threaded(obj, pstate);
+        progress |= graph_walker(block, {
+                                            [&](std::shared_ptr<CFGNode> b) {
+                                                return instruction_walker(
+                                                    *b, {[&](const Instruction & obj) {
+                                                        return replace_threaded(obj, pstate);
+                                                    }});
+                                            },
                                         });
-                                    },
-                                });
     }
     return progress;
 }

--- a/src/mir/passes/threaded.cpp
+++ b/src/mir/passes/threaded.cpp
@@ -231,7 +231,7 @@ std::optional<Instruction> replace_threaded(const Instruction & obj, State::Pers
 
 } // namespace
 
-bool threaded_lowering(std::shared_ptr<BasicBlock> block, State::Persistant & pstate) {
+bool threaded_lowering(std::shared_ptr<CFGNode> block, State::Persistant & pstate) {
     bool progress = false;
     FindList jobs{};
 
@@ -241,7 +241,7 @@ bool threaded_lowering(std::shared_ptr<BasicBlock> block, State::Persistant & ps
     //  3. call the block walker again to fill in those values
     progress |=
         block_walker(block, {
-                                [&](std::shared_ptr<BasicBlock> b) {
+                                [&](std::shared_ptr<CFGNode> b) {
                                     return function_walker(*b, [&](const Instruction & obj) {
                                         return search_threaded(obj, pstate, jobs);
                                     });
@@ -251,7 +251,7 @@ bool threaded_lowering(std::shared_ptr<BasicBlock> block, State::Persistant & ps
         search_for_threaded_impl(jobs, pstate);
         progress |=
             block_walker(block, {
-                                    [&](std::shared_ptr<BasicBlock> b) {
+                                    [&](std::shared_ptr<CFGNode> b) {
                                         return function_walker(*b, [&](const Instruction & obj) {
                                             return replace_threaded(obj, pstate);
                                         });

--- a/src/mir/passes/threaded.cpp
+++ b/src/mir/passes/threaded.cpp
@@ -240,7 +240,7 @@ bool threaded_lowering(std::shared_ptr<CFGNode> block, State::Persistant & pstat
     //  2. create the threads and send them to work on filling out those futures
     //  3. call the block walker again to fill in those values
     progress |=
-        block_walker(block, {
+        graph_walker(block, {
                                 [&](std::shared_ptr<CFGNode> b) {
                                     return function_walker(*b, [&](const Instruction & obj) {
                                         return search_threaded(obj, pstate, jobs);
@@ -250,7 +250,7 @@ bool threaded_lowering(std::shared_ptr<CFGNode> block, State::Persistant & pstat
     if (progress) {
         search_for_threaded_impl(jobs, pstate);
         progress |=
-            block_walker(block, {
+            graph_walker(block, {
                                     [&](std::shared_ptr<CFGNode> b) {
                                         return function_walker(*b, [&](const Instruction & obj) {
                                             return replace_threaded(obj, pstate);

--- a/src/mir/passes/value_numbering.cpp
+++ b/src/mir/passes/value_numbering.cpp
@@ -59,7 +59,7 @@ bool GlobalValueNumbering::insert_phis(CFGNode & b) {
         }
     }
 
-    b.instructions.splice(b.instructions.begin(), phis);
+    b.block->instructions.splice(b.block->instructions.begin(), phis);
 
     return true;
 };

--- a/src/mir/passes/value_numbering.cpp
+++ b/src/mir/passes/value_numbering.cpp
@@ -12,7 +12,7 @@ namespace MIR::Passes {
 
 bool GlobalValueNumbering::insert_phis(BasicBlock & b) {
     // Merge the data down, even for strictly dominated blocks
-    for (auto && p : b.parents) {
+    for (auto && p : b.predecessors) {
         for (auto && [var, value] : data[p->index]) {
             if (data[b.index].find(var) == data[b.index].end()) {
                 data[b.index][var] = value;
@@ -22,17 +22,17 @@ bool GlobalValueNumbering::insert_phis(BasicBlock & b) {
         }
     }
 
-    if (b.parents.size() <= 1) {
+    if (b.predecessors.size() <= 1) {
         return false;
     }
 
     // Calculate all variables that have convergence
     //
-    // This is true if a variable is present in at least two parents
+    // This is true if a variable is present in at least two predecessors
     std::vector<std::tuple<std::string, std::vector<uint32_t>>> convergence{};
     for (auto && [var, _] : data[b.index]) {
         std::vector<uint32_t> values;
-        for (auto && p : b.parents) {
+        for (auto && p : b.predecessors) {
             if (auto && i = data[p->index].find(var); i != data[p->index].end()) {
                 values.emplace_back(i->second);
             }

--- a/src/mir/passes/value_numbering.cpp
+++ b/src/mir/passes/value_numbering.cpp
@@ -10,7 +10,7 @@
 
 namespace MIR::Passes {
 
-bool GlobalValueNumbering::insert_phis(BasicBlock & b) {
+bool GlobalValueNumbering::insert_phis(CFGNode & b) {
     // Merge the data down, even for strictly dominated blocks
     for (auto && r : b.predecessors) {
         auto p = r.lock();
@@ -97,7 +97,7 @@ bool GlobalValueNumbering::number(Instruction & obj, const uint32_t block_index)
     return progress;
 }
 
-bool GlobalValueNumbering::operator()(std::shared_ptr<BasicBlock> block) {
+bool GlobalValueNumbering::operator()(std::shared_ptr<CFGNode> block) {
     // Don't run this pass on the same data twice
     if (data.find(block->index) != data.end()) {
         return false;

--- a/src/mir/passes/walkers.cpp
+++ b/src/mir/passes/walkers.cpp
@@ -89,12 +89,12 @@ bool instruction_walker(CFGNode & block, const std::vector<MutationCallback> & f
                         const std::vector<ReplacementCallback> & rc) {
     bool progress = false;
 
-    for (auto it = block.instructions.begin(); it != block.instructions.end(); ++it) {
+    for (auto it = block.block->instructions.begin(); it != block.block->instructions.end(); ++it) {
         for (const auto & cb : rc) {
             auto rt = cb(*it);
             if (rt.has_value()) {
-                it = block.instructions.erase(it);
-                it = block.instructions.insert(it, std::move(rt.value()));
+                it = block.block->instructions.erase(it);
+                it = block.block->instructions.insert(it, std::move(rt.value()));
                 progress |= true;
             }
         }

--- a/src/mir/passes/walkers.cpp
+++ b/src/mir/passes/walkers.cpp
@@ -245,7 +245,7 @@ bool function_walker(CFGNode & block, const MutationCallback & cb) {
     return progress;
 };
 
-bool block_walker(std::shared_ptr<CFGNode> root, const std::vector<BlockWalkerCb> & callbacks) {
+bool graph_walker(std::shared_ptr<CFGNode> root, const std::vector<BlockWalkerCb> & callbacks) {
     bool progress = false;
 
     BlockIterator iter{root};

--- a/src/mir/passes/walkers.cpp
+++ b/src/mir/passes/walkers.cpp
@@ -61,13 +61,13 @@ class BlockIterator {
     std::set<const BasicBlock *, BBComparitor> seen;
 
     void add_todo(std::shared_ptr<BasicBlock> b) {
-        if (b != nullptr && !block_worked(b.get()) && all_parents_seen(b.get())) {
+        if (b != nullptr && !block_worked(b.get()) && all_predecessors_seen(b.get())) {
             todo.emplace_back(b);
         }
     }
 
-    bool all_parents_seen(const BasicBlock * b) const {
-        return std::all_of(b->parents.begin(), b->parents.end(),
+    bool all_predecessors_seen(const BasicBlock * b) const {
+        return std::all_of(b->predecessors.begin(), b->predecessors.end(),
                            [this](const BasicBlock * p) { return this->block_worked(p); });
     }
 

--- a/src/mir/passes/walkers.cpp
+++ b/src/mir/passes/walkers.cpp
@@ -13,18 +13,6 @@ namespace MIR::Passes {
 
 namespace {
 
-bool replace_elements(std::vector<Instruction> & vec, const ReplacementCallback & cb) {
-    bool progress = false;
-    for (auto it = vec.begin(); it != vec.end(); ++it) {
-        auto rt = cb(*it);
-        if (rt.has_value()) {
-            vec[it - vec.begin()] = rt.value();
-            progress |= true;
-        }
-    }
-    return progress;
-}
-
 class BlockIterator {
   private:
     std::shared_ptr<CFGNode> current;
@@ -68,6 +56,100 @@ class BlockIterator {
     }
 };
 
+bool mutation_visitor(Instruction & it, MutationCallback cb) {
+    bool progress = false;
+
+    if (auto * a = std::get_if<MIR::Array>(it.obj_ptr.get())) {
+        for (auto & a : a->value) {
+            progress |= mutation_visitor(a, cb);
+        }
+    } else if (auto * d = std::get_if<MIR::Dict>(it.obj_ptr.get())) {
+        for (auto & [_, v] : d->value) {
+            progress |= mutation_visitor(v, cb);
+        }
+    } else if (auto * f = std::get_if<MIR::FunctionCall>(it.obj_ptr.get())) {
+        for (auto & p : f->pos_args) {
+            progress |= mutation_visitor(p, cb);
+        }
+        for (auto & [_, v] : f->kw_args) {
+            progress |= mutation_visitor(v, cb);
+        }
+        progress |= mutation_visitor(f->holder, cb);
+    } else if (auto * j = std::get_if<MIR::Jump>(it.obj_ptr.get())) {
+        if (j->predicate) {
+            progress |= mutation_visitor(*j->predicate, cb);
+        }
+    } else if (auto * b = std::get_if<MIR::Branch>(it.obj_ptr.get())) {
+        for (auto & [i, _] : b->branches) {
+            progress |= mutation_visitor(i, cb);
+        }
+    }
+    progress |= cb(it);
+
+    return progress;
+}
+
+bool replacement_visitor(const Instruction & it, const ReplacementCallback & cb);
+
+bool replace_elements(std::vector<Instruction> & vec, const ReplacementCallback & cb) {
+    bool progress = false;
+    for (auto it = vec.begin(); it != vec.end(); ++it) {
+        progress |= replacement_visitor(*it, cb);
+        auto rt = cb(*it);
+        if (rt.has_value()) {
+            vec[it - vec.begin()] = rt.value();
+            progress |= true;
+        }
+    }
+    return progress;
+}
+
+bool replace_elements(std::unordered_map<std::string, Instruction> & map,
+                      const ReplacementCallback & cb) {
+    bool progress = false;
+    for (auto it = map.begin(); it != map.end(); ++it) {
+        progress |= replacement_visitor(it->second, cb);
+        auto rt = cb(it->second);
+        if (rt.has_value()) {
+            map[it->first] = rt.value();
+            progress |= true;
+        }
+    }
+    return progress;
+}
+
+bool replacement_visitor(const Instruction & it, const ReplacementCallback & cb) {
+    bool progress = false;
+
+    if (auto * a = std::get_if<MIR::Array>(it.obj_ptr.get())) {
+        progress |= replace_elements(a->value, cb);
+    } else if (auto * d = std::get_if<MIR::Dict>(it.obj_ptr.get())) {
+        progress |= replace_elements(d->value, cb);
+    } else if (auto * f = std::get_if<MIR::FunctionCall>(it.obj_ptr.get())) {
+        progress |= replace_elements(f->pos_args, cb);
+        progress |= replace_elements(f->kw_args, cb);
+        progress |= replacement_visitor(f->holder, cb);
+    } else if (auto * j = std::get_if<MIR::Jump>(it.obj_ptr.get())) {
+        if (j->predicate) {
+            progress |= replacement_visitor(*j->predicate, cb);
+            if (auto rt = cb(*j->predicate)) {
+                j->predicate = std::make_shared<Instruction>(rt.value());
+                progress |= true;
+            }
+        }
+    } else if (auto * b = std::get_if<MIR::Branch>(it.obj_ptr.get())) {
+        for (auto it2 = b->branches.begin(); it2 != b->branches.end(); ++it2) {
+            progress |= replacement_visitor(std::get<0>(*it2), cb);
+            if (auto rt = cb(std::get<0>(*it2))) {
+                b->branches[it2 - b->branches.begin()] =
+                    std::make_tuple(rt.value(), std::get<1>(*it2));
+                progress |= true;
+            }
+        }
+    }
+    return progress;
+}
+
 } // namespace
 
 bool instruction_walker(CFGNode & block, const std::vector<MutationCallback> & fc) {
@@ -84,146 +166,17 @@ bool instruction_walker(CFGNode & block, const std::vector<MutationCallback> & f
 
     for (auto it = block.block->instructions.begin(); it != block.block->instructions.end(); ++it) {
         for (const auto & cb : rc) {
-            auto rt = cb(*it);
-            if (rt.has_value()) {
+            progress |= replacement_visitor(*it, cb);
+            if (auto rt = cb(*it)) {
                 it = block.block->instructions.erase(it);
                 it = block.block->instructions.insert(it, std::move(rt.value()));
                 progress |= true;
             }
         }
         for (const auto & cb : fc) {
-            progress |= cb(*it);
+            progress |= mutation_visitor(*it, cb);
         }
     }
-
-    return progress;
-};
-
-bool array_walker(Instruction & obj, const MutationCallback & cb) {
-    bool progress = false;
-
-    auto arr_ptr = std::get_if<Array>(obj.obj_ptr.get());
-    if (arr_ptr == nullptr) {
-        return progress;
-    }
-
-    for (auto & e : arr_ptr->value) {
-        if (std::holds_alternative<Array>(*e.obj_ptr)) {
-            progress |= array_walker(e, cb);
-        } else {
-            progress |= cb(e);
-        }
-    }
-
-    return progress;
-}
-
-bool array_walker(const Instruction & obj, const ReplacementCallback & cb) {
-    bool progress = false;
-
-    auto arr_ptr = std::get_if<Array>(obj.obj_ptr.get());
-    if (arr_ptr == nullptr) {
-        return progress;
-    }
-
-    for (auto it = arr_ptr->value.begin(); it != arr_ptr->value.end(); ++it) {
-        if (std::holds_alternative<Array>(*it->obj_ptr)) {
-            progress |= array_walker(*it, cb);
-        } else {
-            auto rt = cb(*it);
-            if (rt.has_value()) {
-                arr_ptr->value[it - arr_ptr->value.begin()] = rt.value();
-                progress |= true;
-            }
-        }
-    }
-
-    return progress;
-}
-
-bool function_argument_walker(const Instruction & obj, const ReplacementCallback & cb) {
-    bool progress = false;
-
-    auto func_ptr = std::get_if<FunctionCall>(obj.obj_ptr.get());
-    if (func_ptr == nullptr) {
-        return progress;
-    }
-
-    if (!func_ptr->pos_args.empty()) {
-        progress |= replace_elements(func_ptr->pos_args, cb);
-    }
-
-    if (!func_ptr->kw_args.empty()) {
-        for (auto & [n, v] : func_ptr->kw_args) {
-            if (std::holds_alternative<Array>(*v.obj_ptr)) {
-                progress |= array_walker(v, cb);
-            }
-            // If the callback can act on arrays (like flatten can), we need to
-            // call the cb on the array, and on the array elements
-            if (std::optional<Instruction> o = cb(v); o.has_value()) {
-                func_ptr->kw_args[n] = o.value();
-                progress |= true;
-            }
-        }
-    }
-
-    return progress;
-}
-
-bool function_argument_walker(Instruction & obj, const MutationCallback & cb) {
-    bool progress = false;
-
-    auto func_ptr = std::get_if<FunctionCall>(obj.obj_ptr.get());
-    if (func_ptr == nullptr) {
-        return progress;
-    }
-
-    for (auto & e : func_ptr->pos_args) {
-        progress |= cb(e);
-        progress |= array_walker(e, cb);
-    }
-
-    if (!func_ptr->kw_args.empty()) {
-        for (auto & [_, v] : func_ptr->kw_args) {
-            progress |= cb(v);
-            progress |= array_walker(v, cb);
-        }
-    }
-
-    return progress;
-}
-
-bool function_walker(CFGNode & block, const ReplacementCallback & cb) {
-    bool progress = instruction_walker(
-        block,
-        {
-            [&](const Instruction & obj) { return array_walker(obj, cb); }, // look into arrays
-            // look into function arguments
-            [&](const Instruction & obj) { return function_argument_walker(obj, cb); },
-            // TODO: look into dictionary elements
-        },
-        {cb});
-
-    // TODO: conditions where previously handled here
-    // What to do about predicated jumps?
-
-    return progress;
-};
-
-bool function_walker(CFGNode & block, const MutationCallback & cb) {
-    bool progress = instruction_walker(
-        block,
-        {
-            [&](Instruction & obj) { return array_walker(obj, cb); }, // look into arrays
-            // look into function arguments
-            [&](Instruction & obj) { return function_argument_walker(obj, cb); },
-            // TODO: look into dictionary elements
-            cb,
-        },
-        {});
-
-    // TODO: conditions where previously handled here
-    // What to do about predicated jumps?
 
     return progress;
 };


### PR DESCRIPTION
This replace the implicit outputs of basic blocks with a higher level graph construct that holds the basic block and two new instructions, jump and branch. These instructions allow for more expressive blocks, like jumps in the middle of blocks (subdir_done()), as well as expressing foreach loops

Closes: #99