### PR TITLE
mir: Introduce a Meson object for the `meson` namespace

### DIFF
--- a/src/mir/ast_to_mir.cpp
+++ b/src/mir/ast_to_mir.cpp
@@ -78,6 +78,9 @@ struct ExpressionLowering {
     };
 
     Object operator()(const std::unique_ptr<Frontend::AST::Identifier> & expr) const {
+        if (expr->value == "meson") {
+            return std::make_shared<Meson>();
+        }
         return std::make_shared<Identifier>(expr->value);
     };
 

--- a/src/mir/mir.cpp
+++ b/src/mir/mir.cpp
@@ -446,6 +446,10 @@ std::string Disabler::print() const { return "disabler { }"; }
 
 bool Disabler::is_reduced() const { return true; }
 
+std::string Meson::print() const { return "Meson { }"; }
+
+bool Meson::is_reduced() const { return true; }
+
 void link_nodes(std::shared_ptr<CFGNode> predecessor, std::shared_ptr<CFGNode> successor) {
     successor->predecessors.emplace(predecessor);
     predecessor->successors.emplace(successor);

--- a/src/mir/mir.hpp
+++ b/src/mir/mir.hpp
@@ -84,6 +84,7 @@ class Test;
 class Jump;
 class Branch;
 class Disabler;
+class Meson;
 
 using AddArgumentsPtr = std::shared_ptr<AddArguments>;
 using FunctionCallPtr = std::shared_ptr<FunctionCall>;
@@ -107,12 +108,13 @@ using TestPtr = std::shared_ptr<Test>;
 using JumpPtr = std::shared_ptr<Jump>;
 using BranchPtr = std::shared_ptr<Branch>;
 using DisablerPtr = std::shared_ptr<Disabler>;
+using MesonPtr = std::shared_ptr<Meson>;
 
 using Object =
     std::variant<AddArgumentsPtr, FunctionCallPtr, StringPtr, BooleanPtr, NumberPtr, IdentifierPtr,
                  ArrayPtr, DictPtr, CompilerPtr, FilePtr, ExecutablePtr, StaticLibraryPtr, PhiPtr,
                  IncludeDirectoriesPtr, MessagePtr, ProgramPtr, CustomTargetPtr, DependencyPtr,
-                 TestPtr, JumpPtr, BranchPtr, DisablerPtr>;
+                 TestPtr, JumpPtr, BranchPtr, DisablerPtr, MesonPtr>;
 
 using Callable = std::variant<FilePtr, ExecutablePtr, ProgramPtr>;
 
@@ -664,6 +666,17 @@ class Branch {
     Variable var;
 };
 
+class Meson {
+  public:
+    Meson() = default;
+
+    Variable var;
+
+    std::string print() const;
+
+    bool is_reduced() const;
+};
+
 class BasicBlock {
   public:
     BasicBlock() = default;
@@ -731,6 +744,7 @@ struct VariableGetter {
     Variable & operator()(const StaticLibraryPtr & o) const { return o->var; }
     Variable & operator()(const StringPtr & o) const { return o->var; }
     Variable & operator()(const TestPtr & o) const { return o->var; }
+    Variable & operator()(const MesonPtr & o) const { return o->var; }
 };
 
 struct VariableSetter {
@@ -759,6 +773,7 @@ struct VariableSetter {
     void operator()(StaticLibraryPtr & o) const { o->var = var; }
     void operator()(StringPtr & o) const { o->var = var; }
     void operator()(TestPtr & o) const { o->var = var; }
+    void operator()(MesonPtr & o) const { o->var = var; }
 };
 
 void set_var(const Object & src, Object & dest);

--- a/src/mir/passes/compilers.cpp
+++ b/src/mir/passes/compilers.cpp
@@ -16,10 +16,7 @@ inline bool valid_holder(const std::optional<Object> & holder) {
     }
     auto && held = holder.value();
 
-    if (!std::holds_alternative<IdentifierPtr>(held)) {
-        return false;
-    }
-    return std::get<IdentifierPtr>(held)->value == "meson";
+    return std::holds_alternative<MesonPtr>(held);
 }
 
 using ToolchainMap =


### PR DESCRIPTION
I initially considered simply looking for functions with `meson` as their held object and replacing them with some kind of free function type, however, meson allows for this:
```meson
x = meson
cc = x.get_compiler('c')
```
Which means we have to be able to const-propagate that assignment to resolve the meson namespace.